### PR TITLE
Add snakeviz & speedscope profiling options

### DIFF
--- a/notebooks/Benchmarking-Postprocess.ipynb
+++ b/notebooks/Benchmarking-Postprocess.ipynb
@@ -84,14 +84,9 @@
     }
    ],
    "source": [
-    "from deepcell.applications import Mesmer\n",
-    "import tensorflow as tf\n",
+    "from imaging_helpers import make_app\n",
     "\n",
-    "t = timeit.default_timer()\n",
-    "model = tf.keras.models.load_model(model_path)\n",
-    "print('Loaded model in %s s' % (timeit.default_timer() - t))\n",
-    "\n",
-    "app = Mesmer(model=model)"
+    "app = make_app(model_path=model_path)"
    ]
   },
   {
@@ -204,9 +199,27 @@
     "\n",
     "# build_postprocessing_kwargs depends on a PR I haven't submitted to vanvalenlab yet. :(\n",
     "postprocess_kwargs = build_postprocessing_kwargs()\n",
-    "label_image = app._postprocess(output_images, **postprocess_kwargs)\n",
     "\n",
-    "print('Post-process finished in %s s' % (timeit.default_timer() - t))\n"
+    "profiling = 'speedscope'\n",
+    "speedscope_output_path = 'speedscope.json'\n",
+    "\n",
+    "match profiling:\n",
+    "  case 'snakeviz':\n",
+    "    import snakeviz\n",
+    "    %load_ext snakeviz\n",
+    "    %snakeviz -t label_image = app._postprocess(output_images, **postprocess_kwargs)\n",
+    "  case 'speedscope':\n",
+    "    import speedscope\n",
+    "    with speedscope.track(speedscope_output_path):\n",
+    "        label_image = app._postprocess(output_images, **postprocess_kwargs)\n",
+    "  case _:\n",
+    "    label_image = app._postprocess(output_images, **postprocess_kwargs)\n",
+    "\n",
+    "print('Post-process finished in %s s' % (timeit.default_timer() - t))\n",
+    "\n",
+    "# To open new tab on snakeviz profiling,\n",
+    "# $ snakeviz /var/folders/nz/qx4dxfys0_l2tn57sz_dyn440000gn/T/tmp645j9al3\n",
+    "# where you use the path from the log: Profile stats marshalled to file '...'\n"
    ]
   }
  ],

--- a/notebooks/Predict-Segments.ipynb
+++ b/notebooks/Predict-Segments.ipynb
@@ -80,14 +80,9 @@
     }
    ],
    "source": [
-    "from deepcell.applications import Mesmer\n",
-    "import tensorflow as tf\n",
+    "from imaging_helpers import make_app\n",
     "\n",
-    "t = timeit.default_timer()\n",
-    "model = tf.keras.models.load_model(model_path)\n",
-    "print('Loaded model in %s s' % (timeit.default_timer() - t))\n",
-    "\n",
-    "app = Mesmer(model=model)"
+    "app = make_app(model_path=model_path)"
    ]
   },
   {
@@ -284,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/imaging_helpers.py
+++ b/notebooks/imaging_helpers.py
@@ -1,0 +1,12 @@
+import timeit
+
+from deepcell.applications import Mesmer
+import tensorflow as tf
+
+
+def make_app(model_path):
+    t = timeit.default_timer()
+    model = tf.keras.models.load_model(model_path)
+    print("Loaded model in %s s" % (timeit.default_timer() - t))
+
+    return Mesmer(model=model)

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,0 +1,1 @@
+snakeviz


### PR DESCRIPTION
Extend the postprocessing benchmarking notebook with snakeviz & speedscope profiling.  Use a variable to specify which mode; it then either opens a snakeviz tab or generates a speedscope.json file when postprocessing is complete.

Note that snakeviz's underlying profile is sampled so not all time is accounted for and sometimes the call stack looks off. Speedscope captures the time more precisely.

Use speedscope at: http://speedscope.app