### PR TITLE
Add sample predictions & segmentation visualization

### DIFF
--- a/notebooks/Predict-Segments.ipynb
+++ b/notebooks/Predict-Segments.ipynb
@@ -43,9 +43,20 @@
    "outputs": [],
    "source": [
     "# Parameters (overridden by notebook parameters)\n",
-    "input_channels_path = './saves/input_channels.npz'\n",
-    "model_path = os.path.expanduser('~') + '/.keras/models/MultiplexSegmentation'\n",
-    "output_path = './saves'"
+    "\n",
+    "root_path = '../sample-data/deepcell/mesmer-sample-3'\n",
+    "model_path = os.path.expanduser('~') + '/.keras/models/MultiplexSegmentation'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a0e5da10-d92f-49a7-8cd1-49a3c5c260dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_channels_path = '{}/input_channels.npz'.format(root_path)\n",
+    "output_path = root_path"
    ]
   },
   {
@@ -58,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "3e2b52df-f15e-4bcb-a07f-5c61580f582d",
    "metadata": {},
    "outputs": [
@@ -66,7 +77,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-07-10 15:25:31.047780: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "2023-11-03 18:27:46.647618: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
      ]
     },
@@ -75,13 +86,14 @@
      "output_type": "stream",
      "text": [
       "WARNING:tensorflow:No training configuration found in save file, so the model was *not* compiled. Compile it manually.\n",
-      "Loaded model in 25.463194751995616 s\n"
+      "Loaded model in 24.941387450002367 s\n"
      ]
     }
    ],
    "source": [
     "from imaging_helpers import make_app\n",
     "\n",
+    "# Assumes that the model has been downloaded already.\n",
     "app = make_app(model_path=model_path)"
    ]
   },
@@ -95,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "ca6be53e-98fa-49f8-88f2-0c56f5edb4aa",
    "metadata": {
     "editable": true,
@@ -108,15 +120,12 @@
    "source": [
     "import numpy as np\n",
     "\n",
+    "# An array of shape [height, width, 2] containing nuclear & membrane channels\n",
     "with np.load(input_channels_path) as loader:\n",
-    "    # An array of shape [num_inputs, height, width] containing intensity of nuclear channel\n",
-    "    inputs_nuclear = loader['nuclear']\n",
+    "    input_channels = loader['input_channels']\n",
     "\n",
-    "    # An array of shape [num_inputs, height, width] containing intensity of membrane channel\n",
-    "    inputs_membrane = loader['membrane']\n",
-    "\n",
-    "# An array of shape [num_inputs, height, width, 2] containing nuclear & membrane channels\n",
-    "input_channels = np.stack((inputs_nuclear, inputs_membrane), axis=-1)"
+    "# Conform to DeepCell's expected shape [num_inputs, height, width, 2]\n",
+    "input_channels = input_channels[np.newaxis, ...]"
    ]
   },
   {
@@ -131,28 +140,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "d8866adc-5185-4590-9cac-ecaabe6fa186",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:root:Converting image dtype to float\n",
-      "DEBUG:Mesmer:Pre-processed data with mesmer_preprocess in 53.38774848601315 s\n",
-      "DEBUG:Mesmer:Model inference finished in 927.9249126589857 s\n",
-      "DEBUG:Mesmer:Post-processing results with mesmer_postprocess and kwargs: {'whole_cell_kwargs': {'maxima_threshold': 0.075, 'maxima_smooth': 0, 'interior_threshold': 0.2, 'interior_smooth': 2, 'small_objects_threshold': 15, 'fill_holes_threshold': 15, 'radius': 2}, 'nuclear_kwargs': {'maxima_threshold': 0.1, 'maxima_smooth': 0, 'interior_threshold': 0.2, 'interior_smooth': 2, 'small_objects_threshold': 15, 'fill_holes_threshold': 15, 'radius': 2}, 'compartment': 'whole-cell'}\n",
-      "/Users/davidhaley/dev/deepcell-imaging/notebooks/venv/lib/python3.10/site-packages/deepcell_toolbox/deep_watershed.py:108: UserWarning: h_maxima peak finding algorithm was selected, but the provided image is larger than 5k x 5k pixels.This will lead to slow prediction performance.\n",
-      "  warnings.warn('h_maxima peak finding algorithm was selected, '\n",
-      "DEBUG:Mesmer:Post-processed results with mesmer_postprocess in 275.2320215930231 s\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Prediction finished in 1326.915612539975 s\n"
+      "Prediction finished in 4.256865661998745 s\n"
      ]
     }
    ],
@@ -162,11 +158,7 @@
     "import logging\n",
     "logging.root.setLevel(logging.DEBUG)\n",
     "\n",
-    "import tracemalloc\n",
-    "tracemalloc.start()\n",
-    "segmentation_predictions = app.predict(input_channels, image_mpp=0.5)\n",
-    "snapshot = tracemalloc.take_snapshot()\n",
-    "tracemalloc.stop()\n",
+    "predictions = app.predict(input_channels, image_mpp=0.5)[0]\n",
     "\n",
     "print('Prediction finished in %s s' % (timeit.default_timer() - t))"
    ]
@@ -177,72 +169,6 @@
    "metadata": {},
    "source": [
     "# Save predictions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "4f178b86-23e6-4ce3-93d5-965963ac029b",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Top 10 lines\n",
-      "#1: <__array_function__ internals>:180: 543818.9 KiB\n",
-      "#2: internal/python_message.py:1501: 1160.9 KiB\n",
-      "    self._parent_message_weakref = weakref.proxy(parent_message)\n",
-      "#3: internal/decoder.py:553: 1017.3 KiB\n",
-      "    value = str(byte_str, 'utf-8')\n",
-      "#4: framework/ops.py:500: 971.3 KiB\n",
-      "    self._consumers = []\n",
-      "#5: internal/python_message.py:1465: 762.4 KiB\n",
-      "    other_field = self._oneofs.setdefault(field.containing_oneof, field)\n",
-      "#6: framework/ops.py:2110: 512.5 KiB\n",
-      "    self._graph = g\n",
-      "#7: python3.10/abc.py:123: 470.4 KiB\n",
-      "    return _abc_subclasscheck(cls, subclass)\n",
-      "#8: internal/python_message.py:1338: 412.0 KiB\n",
-      "    self._fields[field] = value\n",
-      "#9: internal/containers.py:441: 363.6 KiB\n",
-      "    new_element = self._message_descriptor._concrete_class()\n",
-      "#10: python3.10/linecache.py:137: 334.7 KiB\n",
-      "    lines = fp.readlines()\n",
-      "1772 other: 6704.6 KiB\n",
-      "Total allocated size: 556528.5 KiB\n"
-     ]
-    }
-   ],
-   "source": [
-    "import linecache\n",
-    "def display_top(snapshot, key_type='lineno', limit=3):\n",
-    "    snapshot = snapshot.filter_traces((\n",
-    "        tracemalloc.Filter(False, \"<frozen importlib._bootstrap>\"),\n",
-    "        tracemalloc.Filter(False, \"<unknown>\"),\n",
-    "    ))\n",
-    "    top_stats = snapshot.statistics(key_type)\n",
-    "\n",
-    "    print(\"Top %s lines\" % limit)\n",
-    "    for index, stat in enumerate(top_stats[:limit], 1):\n",
-    "        frame = stat.traceback[0]\n",
-    "        # replace \"/path/to/module/file.py\" with \"module/file.py\"\n",
-    "        filename = os.sep.join(frame.filename.split(os.sep)[-2:])\n",
-    "        print(\"#%s: %s:%s: %.1f KiB\"\n",
-    "              % (index, filename, frame.lineno, stat.size / 1024))\n",
-    "        line = linecache.getline(frame.filename, frame.lineno).strip()\n",
-    "        if line:\n",
-    "            print('    %s' % line)\n",
-    "\n",
-    "    other = top_stats[limit:]\n",
-    "    if other:\n",
-    "        size = sum(stat.size for stat in other)\n",
-    "        print(\"%s other: %.1f KiB\" % (len(other), size / 1024))\n",
-    "    total = sum(stat.size for stat in top_stats)\n",
-    "    print(\"Total allocated size: %.1f KiB\" % (total / 1024))\n",
-    "\n",
-    "\n",
-    "display_top(snapshot, limit=10)"
    ]
   },
   {
@@ -259,7 +185,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "np.savez_compressed(output_path + '/segmentation_predictions.npz', predictions=segmentation_predictions)"
+    "np.savez_compressed('{}/predictions.npz'.format(output_path), predictions=predictions)"
    ]
   }
  ],

--- a/notebooks/Visualize-Segmentation.ipynb
+++ b/notebooks/Visualize-Segmentation.ipynb
@@ -30,9 +30,19 @@
    "outputs": [],
    "source": [
     "# Parameters (overridden by notebook parameters)\n",
-    "rgb_images_path = './saves/visualized_inputs.npz'\n",
-    "predictions_path = './saves/segmentation_predictions.npz'\n",
-    "output_path = './saves'"
+    "root_path = '../sample-data/deepcell/mesmer-sample-3'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "93e6a026-9542-4bd6-a957-4bd1c603d112",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rgb_images_path = '{}/input_rgb.npz'.format(root_path)\n",
+    "predictions_path = '{}/predictions.npz'.format(root_path)\n",
+    "output_path = root_path"
    ]
   },
   {
@@ -51,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "997ce2ef-c098-4627-b299-4604a4ea3da0",
    "metadata": {
     "editable": true,
@@ -66,10 +76,10 @@
     "import numpy as np\n",
     "\n",
     "with np.load(rgb_images_path) as loader:\n",
-    "    input_rgbs = loader['rgb']\n",
+    "    input_rgb = loader['rgb']\n",
     "\n",
     "with np.load(predictions_path) as loader:\n",
-    "    segmentation_predictions = predictions = loader['predictions']"
+    "    predictions = loader['predictions']"
    ]
   },
   {
@@ -82,17 +92,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "a22d6e17-da89-4c6e-b1f4-3abcc7944626",
    "metadata": {},
    "outputs": [],
    "source": [
-    "overlay_data = make_outline_overlay(rgb_data=input_rgbs, predictions=segmentation_predictions)"
+    "# Make the inputs correspond to DeepCell expected shape (num inputs, x, y, channel)\n",
+    "\n",
+    "overlay_data = make_outline_overlay(\n",
+    "    rgb_data=input_rgb[np.newaxis, ...],\n",
+    "    predictions=predictions[np.newaxis, ...],\n",
+    ")[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "70f93833-3b90-4e2b-af45-38c1b06ac4a9",
    "metadata": {
     "editable": true,
@@ -106,9 +121,8 @@
     "from PIL import Image\n",
     "\n",
     "# The rgb values are 0..1, so normalize to 0..255\n",
-    "for index, rgb in enumerate(overlay_data * 255):\n",
-    "    im = Image.fromarray(rgb.astype(np.uint8))\n",
-    "    im.save(output_path + f'/segmented_{index}.png', mode='RGB')"
+    "im = Image.fromarray((overlay_data * 255).astype(np.uint8))\n",
+    "im.save(output_path + f'/predicted_segments.png', mode='RGB')"
    ]
   },
   {
@@ -123,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "6a0dea94-3701-4c1d-b1d3-477573f7a934",
    "metadata": {},
    "outputs": [
@@ -140,14 +154,10 @@
    ],
    "source": [
     "from matplotlib import pyplot as plt\n",
-    "import random\n",
-    "\n",
-    "# Visualize an entry chosen arbitrarily\n",
-    "idx = random.randint(0, len(input_rgbs) - 1)\n",
     "\n",
     "fig, ax = plt.subplots(1, 2, figsize=(12, 12))\n",
-    "ax[0].imshow(input_rgbs[idx, ...])\n",
-    "ax[1].imshow(overlay_data[idx, ...])\n",
+    "ax[0].imshow(input_rgb)\n",
+    "ax[1].imshow(overlay_data)\n",
     "ax[0].set_title('Raw data')\n",
     "ax[1].set_title('Predictions')\n",
     "plt.show()"
@@ -170,7 +180,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/sample-data/deepcell/mesmer-sample-0/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-0/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff4f78a9f28962f8c5f76ea4036d08a4af8052b100bdff6cd7d460b31cd466f5
+size 250817

--- a/sample-data/deepcell/mesmer-sample-0/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-0/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b5b84383c8ce3354b3aec811c6fa44071b78db63278aef66ab38d5ce3aa6a1c
+size 10331

--- a/sample-data/deepcell/mesmer-sample-0/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-0/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98c921629e0dff215b03999b10d67d5ebb445f573af75a7a355fdca9f41404db
+size 2464255

--- a/sample-data/deepcell/mesmer-sample-1/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-1/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:586bf343c28d2aa0ee7bb8877e5a2b1cb1a69a36ce2514d80f847869259949a4
+size 142973

--- a/sample-data/deepcell/mesmer-sample-1/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-1/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3c4ed0bda77f2b07492354f094fbca119eaba5337420c13a3683039a2e853e0
+size 8937

--- a/sample-data/deepcell/mesmer-sample-1/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-1/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35fb92fa3acdff3af2e2a8ec9eb73c5f06bc30e09017e1c6bf9740667d3eb52
+size 2366165

--- a/sample-data/deepcell/mesmer-sample-10/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-10/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d6a0fb46e9102a90999eb07268fea85888457d14f9de2617a314216d02047ff
+size 223276

--- a/sample-data/deepcell/mesmer-sample-10/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-10/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9c6e3e1bb87ff3f0f0be4d48f36521a69d68988ac48a76307f7569efc71d1e8
+size 17588

--- a/sample-data/deepcell/mesmer-sample-10/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-10/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28f6cb9920c89a37315d38b2d1402c4d000c7aec572b1844fe2a68e3f4e35833
+size 2653416

--- a/sample-data/deepcell/mesmer-sample-11/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-11/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4d407e247fca47b205ca5e9bee02cf3cfbd648e83f805993cce948fb8c57ad5
+size 422850

--- a/sample-data/deepcell/mesmer-sample-11/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-11/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c838685511f699729f51e179462a365ba5ddae2a99ddceff954c79f33030c0e9
+size 23252

--- a/sample-data/deepcell/mesmer-sample-11/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-11/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26c33c28aef1596c3ac8eb98d8bd927a142db354b603f635242a76aa390b792e
+size 3467203

--- a/sample-data/deepcell/mesmer-sample-12/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-12/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d34753b37b509d1e56ae9139dd0454a35d917e2a971186249ece7532cd48ad2
+size 405719

--- a/sample-data/deepcell/mesmer-sample-12/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-12/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40a9d772bf49432269c4d0e816108010d3caaef7f41e096d83f732587f4d4135
+size 11354

--- a/sample-data/deepcell/mesmer-sample-12/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-12/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f0284dbead68826ccfde62cf7164f938e61fdaa36445a04b125d50c4e1edb51
+size 2733974

--- a/sample-data/deepcell/mesmer-sample-13/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-13/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95eb8f02e614b0033dc9f46261b135ca515a6683adc427d92b04b6a2d32e9c57
+size 149426

--- a/sample-data/deepcell/mesmer-sample-13/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-13/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58bd678d9f5359af1c83664f1f4c9902ee3c3f7e03a3cb7931a1bdbcac14e6a9
+size 9552

--- a/sample-data/deepcell/mesmer-sample-13/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-13/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9112b8ba4c623e55f6440fbc576aa6ec4c485f401392b3f8440d13723d0844b1
+size 2362478

--- a/sample-data/deepcell/mesmer-sample-14/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-14/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dacbf67ae7d2c5b686483404c975f43fc5627827769b774d63890ec4607c684a
+size 427851

--- a/sample-data/deepcell/mesmer-sample-14/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-14/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e08e6c03f7b9b96cadefe0d98b45af4145686c830c555475de0c40ade6adb5fa
+size 23490

--- a/sample-data/deepcell/mesmer-sample-14/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-14/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a72a35ef6b4fb926d094c2c6fc2d528c349190cf80797062177220bb2fd8a504
+size 3482229

--- a/sample-data/deepcell/mesmer-sample-15/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-15/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f539b5aa1283e8e6f2374a4f06143e9098d27b8f9156cca408b154e5f3963c2
+size 337236

--- a/sample-data/deepcell/mesmer-sample-15/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-15/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb6692312d50040eaf206fc0be750768f3915af3b88c7babfb3253f6ce40b72a
+size 17978

--- a/sample-data/deepcell/mesmer-sample-15/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-15/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:405f88805e88d538c1aafb155ea03331c7706ae315b47061b4eccdfd9ea1e085
+size 2904301

--- a/sample-data/deepcell/mesmer-sample-2/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-2/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4630f7302b67b9ab267c09dd7dd71dbc4e51e9a73d164bcab10904c58567a8b
+size 156209

--- a/sample-data/deepcell/mesmer-sample-2/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-2/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a51629928940b7af371951ca7305bbccfc82f64fe03141e336a11065f45a3c4
+size 9455

--- a/sample-data/deepcell/mesmer-sample-2/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-2/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03e2e0fb505bc9a36f87fab998e5854301806a72a064a5ad45bc031ccd68ef48
+size 2424868

--- a/sample-data/deepcell/mesmer-sample-3/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-3/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af555fc314da88568b10d2f94861b6c18a8da7fb34295b19f7268f850fbeccdf
+size 403832

--- a/sample-data/deepcell/mesmer-sample-3/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-3/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d04148c472ca5618a6e8c061a31887c4ea07eca33b29ba4c737c22cefbd08681
+size 18954

--- a/sample-data/deepcell/mesmer-sample-3/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-3/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4da95747703f47bfba95f31a76586cbdb61cfc8b59843119cb91146914647561
+size 3273408

--- a/sample-data/deepcell/mesmer-sample-4/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-4/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a387c0c906615dcd825cd310fe9d69e2c593feedc6e803cc88740baf0368add6
+size 160404

--- a/sample-data/deepcell/mesmer-sample-4/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-4/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d08e8ae7f4bb990cb8f0fc11be696eb9763f1554273019aadbbd6a957164bbe
+size 11296

--- a/sample-data/deepcell/mesmer-sample-4/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-4/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a44c3ac68465593dcd6010bd28c71da8af634ba671c72be48ead105ae2ba4431
+size 2496287

--- a/sample-data/deepcell/mesmer-sample-5/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-5/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eb0acaf68e1e85e61509727937a4aa04611e72da5b4df5580e048400287cd63
+size 170944

--- a/sample-data/deepcell/mesmer-sample-5/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-5/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63991157b8aea7097555824e90293e30b9721916ae50cfb835152663d5cdde6e
+size 12959

--- a/sample-data/deepcell/mesmer-sample-5/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-5/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c70c0f5b401d85b8743de89188d97249a382e4cbe282fa0d8d219e8e115ee3f9
+size 2452957

--- a/sample-data/deepcell/mesmer-sample-6/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-6/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c78e91fab85bb71d271880728b0ae9b5601f7b472db99102650a999250db142
+size 309934

--- a/sample-data/deepcell/mesmer-sample-6/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-6/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e71b72d472b0412cb7325b341cf986488a5c2279df368462fbe9823402a82daf
+size 18227

--- a/sample-data/deepcell/mesmer-sample-6/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-6/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc078b9107cdb6ad0ab4c7727b1974e8bb109080ca9912c9a5abc2b0a1ae5f57
+size 2902719

--- a/sample-data/deepcell/mesmer-sample-7/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-7/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7682c13c88402e7dc1ceec8019435de34108d1b503f1d5ae49a7dbe3a724927f
+size 222411

--- a/sample-data/deepcell/mesmer-sample-7/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-7/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:619eb2cb50e5d19dae42c4d2ec47aec1e3a96ee8d34f3d8edd2a33ecb0a39720
+size 12035

--- a/sample-data/deepcell/mesmer-sample-7/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-7/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c35a869ce7956959eb36996a0012ebc229d67fde1e497ae346dab2d38aafea5
+size 2674478

--- a/sample-data/deepcell/mesmer-sample-8/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-8/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:128ecddb3a19e29ad69953dbeb68918eacf2b8b73040aadd5d29bfe61aea3574
+size 220811

--- a/sample-data/deepcell/mesmer-sample-8/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-8/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06457b4ca46b125c792d365e544525c6b10828fefc1d34974d8f63dbd8870abf
+size 14820

--- a/sample-data/deepcell/mesmer-sample-8/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-8/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c67d92e92d34f7926a5d00c19381993ef026dde39d316b08b57d136a66d2442
+size 2539914

--- a/sample-data/deepcell/mesmer-sample-9/predicted_segments.png
+++ b/sample-data/deepcell/mesmer-sample-9/predicted_segments.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f8803bacb078f4f8f9b92b3a27ddb4c70196f0eebd34d7d66e080ab449eb02f
+size 343051

--- a/sample-data/deepcell/mesmer-sample-9/predictions.npz
+++ b/sample-data/deepcell/mesmer-sample-9/predictions.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78c6222797560c206f896cc93d4bcdda57f1689e5a0e5f9c268094a7b0010abf
+size 18756

--- a/sample-data/deepcell/mesmer-sample-9/raw_output_images.npz
+++ b/sample-data/deepcell/mesmer-sample-9/raw_output_images.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:428e96428412d7eea20bc74ce62567a640c281719d81e3e0c7acc42041cf69bb
+size 2905546


### PR DESCRIPTION
Adds numpy arrays & PNG images for predicted cell segments, from the DeepCell Mesmer sample data (multiplex-tissue).

![Example segmentation visualization](https://media.githubusercontent.com/media/dchaley/deepcell-imaging/02d9450d813d72f77a5edf9c5dd92f03b402875d/sample-data/deepcell/mesmer-sample-11/predicted_segments.png)