### PR TITLE
Extract single raw output image for convenience

### DIFF
--- a/sample-data/deepcell/mesmer-sample-0/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-0/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c99a4d76240ac1ee00250e07080f49fe6f8291d6fc484b089b8351086d147785
+size 337244

--- a/sample-data/deepcell/mesmer-sample-1/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-1/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eda797695d55f82bf69e2783fd8d885235d40edd8ac342d928cfbde0ce293cb0
+size 290205

--- a/sample-data/deepcell/mesmer-sample-10/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-10/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70f33c2b08b848a0c8b55eb83d38222a2447a44553f559ac1b1c05bbb5498138
+size 503308

--- a/sample-data/deepcell/mesmer-sample-11/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-11/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:409782459fd3df4015efbf395524dbca6172de87bf60890ecdc3be44e3115a6c
+size 935827

--- a/sample-data/deepcell/mesmer-sample-12/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-12/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:485f8ec92e61f4bfb87e3ad2922b64c2aa5797850acd2dfc9ed94a3650f238ea
+size 542633

--- a/sample-data/deepcell/mesmer-sample-13/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-13/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3a0f32dbaa0add6ad4993a4dd3e46339487d2dff07f9132621eb9f4303822e1
+size 257144

--- a/sample-data/deepcell/mesmer-sample-14/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-14/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65febe9e912590a7af9aecc8247c12de024cb70d7ba7632ed218a8be54e62310
+size 940344

--- a/sample-data/deepcell/mesmer-sample-15/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-15/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e06542ceddb4489f7c55b9333b3619a3ccd47e13b5ce10cf5f6e374621a5bafa
+size 607164

--- a/sample-data/deepcell/mesmer-sample-2/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-2/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b8c4935eecdf5166f159eaa1788f7cf2860446861484495d30868f57bc2e22e
+size 323986

--- a/sample-data/deepcell/mesmer-sample-3/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-3/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:506aae3efc0af6dfd63cc32cb9e6fec5d3e2ee2b301125962bbb253fa67b6385
+size 931990

--- a/sample-data/deepcell/mesmer-sample-4/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-4/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7eb784d3cd76f7967afdb3fb6fcae654a1b7b1c62f83ec5a32b5549ecc59005a
+size 342356

--- a/sample-data/deepcell/mesmer-sample-5/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-5/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:675576761cc9bfed3dca0c44b53a7a1bfa48fc450fb23479bafb2b752ea72c08
+size 302841

--- a/sample-data/deepcell/mesmer-sample-6/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-6/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad7f3cb760509d4a8c70aa8abe33bea8dec5f55420478cb4d4756f7cbce683c6
+size 539744

--- a/sample-data/deepcell/mesmer-sample-7/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-7/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da241dc2a308665b8ed7d863e75912d3b9af0ea330caa3470fa626496f372c21
+size 511600

--- a/sample-data/deepcell/mesmer-sample-8/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-8/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1da55023f5c6eb52bd2b0a3d083d874c986aa8ec36e035528ca8a0c31b6e748
+size 475083

--- a/sample-data/deepcell/mesmer-sample-9/raw_output_image.npz
+++ b/sample-data/deepcell/mesmer-sample-9/raw_output_image.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b27dbea2e341e4a16da57d7d8552ce21162e581e2119d483e55285c2d12e40b
+size 573133


### PR DESCRIPTION
The actual raw output object is more complex than just a pixel array but we (so far?) only care about the pixel array. Extract it for convenience.

I did this by running this from the `benchmarking/h_maxima` directory:

```
for x in range(16):
    marker_filename = "../../sample-data/deepcell/mesmer-sample-%s/raw_output_images.npz" % x

    with np.load(marker_filename, allow_pickle=True) as loader:
        marker_data = loader["output_images"]
    marker_data = list(np.ndenumerate(marker_data))[0][1]
    marker_data = marker_data['whole-cell'][0]
    output_filename = "../../sample-data/deepcell/mesmer-sample-%s/raw_output_image.npz" % x
    np.savez_compressed(output_filename, output_image=marker_data)
```