### PR TITLE
Update readme

### DIFF
--- a/benchmarking/deepcell-e2e/README.md
+++ b/benchmarking/deepcell-e2e/README.md
@@ -15,10 +15,10 @@ See also: [sample data README](https://github.com/dchaley/deepcell-imaging/tree/
 - Provision a GCP Vertex AI managed notebook instance
   - Connect to the instance using the link `OPEN JUPYTERLAB`
 - Upload the example notebook
-  - Run [the notebook](deepcell-e2e-benchmark.ipynb), which documents the configuration parameters
+  - Run [the notebook](deepcell-e2e-benchmark.ipynb), which installs dependencies documents the configuration parameters
+    - If you install dependencies this way, you need to restart the kernel after the pip install.
+    - Just run, restart, and re-run – it should be fine.
   - Set the notebook runtime to `tensorflow 2.12 (local)`
+    - But something is off with the kernel? See also: https://github.com/dchaley/deepcell-imaging/issues/59
  
-NOTE: You must set up the model info (create/copy)
-  - at ` /home/jupyter/.keras/models/MultiplexSegmentation`
-
-Tip: To manually install DeepCell, run `pip install deepcell --user` in the VertexAI *terminal* prior to running the test notebook
+Tip: to avoid restarting the kernel after installing dependencies, run: `pip install --user -r requirements.txt` in the VertexAI *terminal* prior to running the benchmark notebook.


### PR DESCRIPTION
cc @lynnlangit    I now see a key thing: installing in the terminal separately avoids restarting the kernel, or, you can just run the notebook with a restart in between ... I noticed the official google samples suggest restarting the kernel from within the notebook.

Not sure if we should push this further, in the meantime this provides 2 paths for getting started, both of which are a bit awkward imo (manual terminal command, or, running then restarting kernel then running)