### PR TITLE
Add test suite for fast hybrid reconstruct

### DIFF
--- a/benchmarking/h_maxima/README.md
+++ b/benchmarking/h_maxima/README.md
@@ -1,0 +1,14 @@
+# h_maxima optimization
+
+Context here: [h_maxima performance](https://github.com/dchaley/deepcell-imaging/issues/8)
+
+TLDR, this work presents a 5-15x optimization for gray reconstruction. The larger the image the greater the speedup.
+
+This directory is the WIP area for prepping the code for merge into scikit.
+
+Apply the (adapted) scikit test suite to the optimized code:
+
+```
+pytest test_reconstruction.py
+```
+

--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -1,0 +1,8 @@
+import numpy as np
+from fasthybridreconstruct import fast_hybrid_reconstruct
+
+def cython_reconstruct_wrapper(marker, mask):
+    mask = np.copy(mask)
+    fast_hybrid_reconstruct(marker, mask, 2)
+    return mask
+

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -1,0 +1,221 @@
+# This file was lifted wholesale from scikit-image
+# https://github.com/scikit-image/scikit-image/blob/0e35d8040d0b0bb409de41f3c0f024f941e09d8a/skimage/morphology/tests/test_reconstruction.py
+# and modified to use my own reconstruction function
+
+import math
+import numpy as np
+import pytest
+from numpy.testing import assert_array_almost_equal
+
+from skimage._shared.utils import _supported_float_type
+
+# from skimage.morphology.grayreconstruct import reconstruction
+from fast_reconstruct_wrapper import cython_reconstruct_wrapper as reconstruction
+
+xfail = pytest.mark.xfail
+
+
+def test_zeros():
+    """Test reconstruction with image and mask of zeros"""
+    assert_array_almost_equal(reconstruction(np.zeros((5, 7)), np.zeros((5, 7))), 0)
+
+
+def test_image_equals_mask():
+    """Test reconstruction where the image and mask are the same"""
+    assert_array_almost_equal(reconstruction(np.ones((7, 5)), np.ones((7, 5))), 1)
+
+
+@xfail(reason="footprint, https://github.com/dchaley/deepcell-imaging/issues/30")
+def test_image_less_than_mask():
+    """Test reconstruction where the image is uniform and less than mask"""
+    image = np.ones((5, 5))
+    mask = np.ones((5, 5)) * 2
+    assert_array_almost_equal(reconstruction(image, mask), 1)
+
+
+@xfail(reason="footprint, https://github.com/dchaley/deepcell-imaging/issues/30")
+def test_one_image_peak():
+    """Test reconstruction with one peak pixel"""
+    image = np.ones((5, 5))
+    image[2, 2] = 2
+    mask = np.ones((5, 5)) * 3
+    assert_array_almost_equal(reconstruction(image, mask), 2)
+
+
+# minsize chosen to test sizes covering use of 8, 16 and 32-bit integers
+# internally
+@xfail(reason="footprint, https://github.com/dchaley/deepcell-imaging/issues/30")
+@pytest.mark.parametrize("minsize", [None, 200, 20000, 40000, 80000])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(
+            np.uint8,
+            marks=xfail(
+                reason="uint8 dtype, https://github.com/dchaley/deepcell-imaging/issues/101"
+            ),
+        ),
+        np.float32,
+    ],
+)
+def test_two_image_peaks(minsize, dtype):
+    """Test reconstruction with two peak pixels isolated by the mask"""
+    image = np.array(
+        [
+            [1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 2, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 3, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1],
+        ],
+        dtype=dtype,
+    )
+
+    mask = np.array(
+        [
+            [4, 4, 4, 1, 1, 1, 1, 1, 1],
+            [4, 4, 4, 1, 1, 1, 1, 1, 1],
+            [4, 4, 4, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 4, 4, 4, 1],
+            [1, 1, 1, 1, 1, 4, 4, 4, 1],
+            [1, 1, 1, 1, 1, 4, 4, 4, 1],
+        ],
+        dtype=dtype,
+    )
+
+    expected = np.array(
+        [
+            [2, 2, 2, 1, 1, 1, 1, 1, 1],
+            [2, 2, 2, 1, 1, 1, 1, 1, 1],
+            [2, 2, 2, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 3, 3, 3, 1],
+            [1, 1, 1, 1, 1, 3, 3, 3, 1],
+            [1, 1, 1, 1, 1, 3, 3, 3, 1],
+        ],
+        dtype=dtype,
+    )
+    if minsize is not None:
+        # increase data size by tiling (done to test various int types)
+        nrow = math.ceil(math.sqrt(minsize / image.size))
+        ncol = math.ceil(minsize / (image.size * nrow))
+        image = np.tile(image, (nrow, ncol))
+        mask = np.tile(mask, (nrow, ncol))
+        expected = np.tile(expected, (nrow, ncol))
+    out = reconstruction(image, mask)
+    assert out.dtype == _supported_float_type(mask.dtype)
+    assert_array_almost_equal(out, expected)
+
+
+@xfail(reason="edge case? https://github.com/dchaley/deepcell-imaging/issues/102")
+def test_zero_image_one_mask():
+    """Test reconstruction with an image of all zeros and a mask that's not"""
+    result = reconstruction(np.zeros((10, 10)), np.ones((10, 10)))
+    assert_array_almost_equal(result, 0)
+
+
+@xfail(reason="method, https://github.com/dchaley/deepcell-imaging/issues/99")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.int8,
+        np.uint8,
+        np.int16,
+        np.uint16,
+        np.int32,
+        np.uint32,
+        np.int64,
+        np.uint64,
+        np.float16,
+        np.float32,
+        np.float64,
+    ],
+)
+def test_fill_hole(dtype):
+    """Test reconstruction by erosion, which should fill holes in mask."""
+    seed = np.array([0, 8, 8, 8, 8, 8, 8, 8, 8, 0], dtype=dtype)
+    mask = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0], dtype=dtype)
+    result = reconstruction(seed, mask, method="erosion")
+    assert result.dtype == _supported_float_type(mask.dtype)
+    expected = np.array([0, 3, 6, 4, 4, 4, 4, 4, 2, 0], dtype=dtype)
+    assert_array_almost_equal(result, expected)
+
+
+@xfail(reason="method, https://github.com/dchaley/deepcell-imaging/issues/99")
+def test_invalid_seed():
+    seed = np.ones((5, 5))
+    mask = np.ones((5, 5))
+    with pytest.raises(ValueError):
+        reconstruction(seed * 2, mask, method="dilation")
+    with pytest.raises(ValueError):
+        reconstruction(seed * 0.5, mask, method="erosion")
+
+
+@xfail(reason="footprint, https://github.com/dchaley/deepcell-imaging/issues/30")
+def test_invalid_footprint():
+    seed = np.ones((5, 5))
+    mask = np.ones((5, 5))
+    with pytest.raises(ValueError):
+        reconstruction(seed, mask, footprint=np.ones((4, 4)))
+    with pytest.raises(ValueError):
+        reconstruction(seed, mask, footprint=np.ones((3, 4)))
+    reconstruction(seed, mask, footprint=np.ones((3, 3)))
+
+
+@xfail(reason="method, https://github.com/dchaley/deepcell-imaging/issues/99")
+def test_invalid_method():
+    seed = np.array([0, 8, 8, 8, 8, 8, 8, 8, 8, 0])
+    mask = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0])
+    with pytest.raises(ValueError):
+        reconstruction(seed, mask, method="foo")
+
+
+@xfail(reason="footprint, https://github.com/dchaley/deepcell-imaging/issues/30")
+@xfail(reason="offset, https://github.com/dchaley/deepcell-imaging/issues/100")
+def test_invalid_offset_not_none():
+    """Test reconstruction with invalid not None offset parameter"""
+    image = np.array(
+        [
+            [1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 2, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 1, 3, 1],
+            [1, 1, 1, 1, 1, 1, 1, 1],
+        ]
+    )
+
+    mask = np.array(
+        [
+            [4, 4, 4, 1, 1, 1, 1, 1],
+            [4, 4, 4, 1, 1, 1, 1, 1],
+            [4, 4, 4, 1, 1, 1, 1, 1],
+            [1, 1, 1, 1, 1, 4, 4, 4],
+            [1, 1, 1, 1, 1, 4, 4, 4],
+            [1, 1, 1, 1, 1, 4, 4, 4],
+        ]
+    )
+    with pytest.raises(ValueError):
+        reconstruction(
+            image,
+            mask,
+            footprint=np.ones((3, 3)),
+            offset=np.array([3, 0]),
+        )
+
+
+@xfail(reason="method, https://github.com/dchaley/deepcell-imaging/issues/99")
+@xfail(reason="footprint, https://github.com/dchaley/deepcell-imaging/issues/30")
+@xfail(reason="offset, https://github.com/dchaley/deepcell-imaging/issues/100")
+def test_offset_not_none():
+    """Test reconstruction with valid offset parameter"""
+    seed = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0])
+    mask = np.array([0, 8, 6, 8, 8, 8, 8, 4, 4, 0])
+    expected = np.array([0, 3, 6, 6, 6, 6, 6, 4, 4, 0])
+
+    assert_array_almost_equal(
+        reconstruction(
+            seed, mask, method="dilation", footprint=np.ones(3), offset=np.array([0])
+        ),
+        expected,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 deepcell==0.12.9
 google-cloud-notebooks
 imagecodecs
+pytest
 smart_open[gcs]
 snakeviz
 tifffile


### PR DESCRIPTION
Adds a test suite for our optimized code, lifted from scikit-image itself.

```
$ pytest test_reconstruction.py
============================ test session starts ============================
platform darwin -- Python 3.10.13, pytest-7.4.4, pluggy-1.3.0
rootdir: /Users/davidhaley/dev/deepcell-imaging/benchmarking/h_maxima
plugins: anyio-3.7.1, typeguard-4.0.0
collected 31 items

test_reconstruction.py ..xxxxxxxxxxxxxxxxxxxxxxxxxxxxx                [100%]

======================= 2 passed, 29 xfailed in 0.80s =======================
```

Most of the tests are currently marked `xfail`, with links to follow-up issues (created in [this milestone](https://github.com/dchaley/deepcell-imaging/milestone/1)).

Closes #98 