### PR TITLE
Add pixel count to benchmark data output

### DIFF
--- a/benchmarking/deepcell-e2e/benchmark.ipynb
+++ b/benchmarking/deepcell-e2e/benchmark.ipynb
@@ -58,6 +58,7 @@
     "from datetime import datetime, timezone\n",
     "import deepcell\n",
     "from deepcell.applications import Mesmer\n",
+    "from functools import reduce\n",
     "import io\n",
     "from itertools import groupby\n",
     "import logging\n",
@@ -190,7 +191,7 @@
      "output_type": "stream",
      "text": [
       "INFO:root:Loading model from /Users/davidhaley/.keras/models/MultiplexSegmentation.\n",
-      "2023-12-18 14:11:11.218617: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "2024-01-08 19:27:23.949711: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
      ]
     },
@@ -206,7 +207,7 @@
      "output_type": "stream",
      "text": [
       "WARNING:tensorflow:No training configuration found in save file, so the model was *not* compiled. Compile it manually.\n",
-      "INFO:root:Loaded model in 28.858756325997092 s\n"
+      "INFO:root:Loaded model in 26.04440486000385 s\n"
      ]
     }
    ],
@@ -266,31 +267,31 @@
      "output_type": "stream",
      "text": [
       "DEBUG:Mesmer:Pre-processing data with mesmer_preprocess and kwargs: {}\n",
-      "DEBUG:Mesmer:Pre-processed data with mesmer_preprocess in 0.1330833749998419 s\n"
+      "DEBUG:Mesmer:Pre-processed data with mesmer_preprocess in 0.09573872399050742 s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded input in 7.158191524002177 s\n"
+      "Loaded input in 4.423365914000897 s\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "DEBUG:Mesmer:Model inference finished in 5.5833059399992635 s\n",
+      "DEBUG:Mesmer:Model inference finished in 5.439006330998382 s\n",
       "DEBUG:Mesmer:Post-processing results with mesmer_postprocess and kwargs: {'whole_cell_kwargs': {'maxima_threshold': 0.075, 'maxima_smooth': 0, 'interior_threshold': 0.2, 'interior_smooth': 2, 'small_objects_threshold': 15, 'fill_holes_threshold': 15, 'radius': 2}, 'nuclear_kwargs': {'maxima_threshold': 0.1, 'maxima_smooth': 0, 'interior_threshold': 0.2, 'interior_smooth': 2, 'small_objects_threshold': 15, 'fill_holes_threshold': 15, 'radius': 2}, 'compartment': 'whole-cell'}\n",
-      "DEBUG:Mesmer:Post-processed results with mesmer_postprocess in 0.26041230900227674 s\n"
+      "DEBUG:Mesmer:Post-processed results with mesmer_postprocess in 0.3438746779866051 s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Prediction finished in 6.048543707001954 s\n",
-      "Overall operation finished in 13.207790273998398 s\n"
+      "Prediction finished in 5.9581321839941666 s\n",
+      "Overall operation finished in 10.382393015024718 s\n"
      ]
     }
    ],
@@ -528,15 +529,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"Input file id\",\"Image size (MB)\",\"Compartment\",\"Benchmark datetime (UTC)\",\"Machine type\",\"GPU type\",\"# GPUs\",\"Batch size\",\"Kernel\",\"Success?\",\"Total time (s)\",\"Peak memory (GB)\",\"Load time (s)\",\"Total prediction time (s)\",\"Prediction overhead (s)\",\"Predict preprocess time (s)\",\"Predict inference time (s)\",\"Predict postprocess time (s)\",\"deepcell-tf version\"\n",
-      "\"mesmer-sample-3-dev\",4.19,\"whole-cell\",\"2023-12-18 22:11:51.460798+00:00\",\"error\",\"None\",0,4,\"python3\",True,13.21,2.3,7.16,6.05,0.07,0.13,5.58,0.26,\"0.12.9\"\n",
+      "\"Input file id\",\"Image size (MB)\",\"Pixels (M)\",\"Compartment\",\"Benchmark datetime (UTC)\",\"Machine type\",\"GPU type\",\"# GPUs\",\"Batch size\",\"Kernel\",\"Success?\",\"Total time (s)\",\"Peak memory (GB)\",\"Load time (s)\",\"Total prediction time (s)\",\"Prediction overhead (s)\",\"Predict preprocess time (s)\",\"Predict inference time (s)\",\"Predict postprocess time (s)\",\"deepcell-tf version\"\n",
+      "\"mesmer-sample-3-dev\",4.19,262144,\"whole-cell\",\"2024-01-09 03:27:58.480992+00:00\",\"error\",\"None\",0,4,\"python3\",True,10.38,2.1,4.42,5.96,0.08,0.1,5.44,0.34,\"0.12.9\"\n",
       "\n"
      ]
     }
    ],
    "source": [
     "headers = [\n",
-    "    'Input file id', 'Image size (MB)', 'Compartment', 'Benchmark datetime (UTC)',\n",
+    "    'Input file id', 'Image size (MB)', 'Pixels (M)', 'Compartment', 'Benchmark datetime (UTC)',\n",
     "    'Machine type', 'GPU type', '# GPUs', 'Batch size', 'Kernel',\n",
     "    'Success?', 'Total time (s)', 'Peak memory (GB)',\n",
     "    'Load time (s)', 'Total prediction time (s)', 'Prediction overhead (s)',\n",
@@ -547,6 +548,9 @@
     "parsed_url = urllib.parse.urlparse(input_channels_path)\n",
     "filename = parsed_url.path.split(\"/\")[-2]\n",
     "image_size = round(input_channels.nbytes / 1000 / 1000, 2)\n",
+    "\n",
+    "# Multiply x * y to get pixel count.\n",
+    "pixels = input_channels.shape[0] * input_channels.shape[1]\n",
     "\n",
     "import ipykernel\n",
     "kernel_name = ipykernel.connect.get_connection_info(unpack=True)[\"kernel_name\"]\n",
@@ -620,7 +624,7 @@
     "deepcell_version = deepcell.__version__\n",
     "\n",
     "writer.writerow([\n",
-    "    filename, image_size, prediction_compartment, datetime.now(timezone.utc),\n",
+    "    filename, image_size, pixels, prediction_compartment, datetime.now(timezone.utc),\n",
     "    machine_type, gpu_name, gpu_count, batch_size, kernel_name,\n",
     "    prediction_success, round(total_time_s, 2), round(peak_mem / memory_unit_factor, 1),\n",
     "    round(input_load_time_s, 2), round(prediction_time_s, 2), round(prediction_overhead_s, 2),\n",


### PR DESCRIPTION
Pixels are more useful than the input size in bytes, as deepcell converts incoming data to 64-bit floats. But 15x10 is the same as 10x15, so just output the total number of pixels. Note that this is x*y, no matter how many channels are in the data.

Fixes #107

Paired with @WeihaoGe1009 