### PR TITLE
Maintain int-->float64 conversion

### DIFF
--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -1,9 +1,13 @@
 import numpy as np
 from fasthybridreconstruct import fast_hybrid_reconstruct
+from skimage._shared.utils import _supported_float_type
 
 
-def cython_reconstruct_wrapper(marker, mask, footprint=None):
-    marker = np.copy(marker)
+def cython_reconstruct_wrapper(marker, mask, footprint=None, inplace=False):
+    if inplace:
+        marker = marker
+    else:
+        marker = marker.astype(_supported_float_type(mask.dtype), copy=True)
 
     if footprint is None:
         footprint = np.ones((3, 3), dtype=bool)

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -42,7 +42,6 @@ def test_one_image_peak():
 
 # minsize chosen to test sizes covering use of 8, 16 and 32-bit integers
 # internally
-@xfail(reason="not sure, https://github.com/dchaley/deepcell-imaging/issues/104")
 @pytest.mark.parametrize("minsize", [None, 200, 20000, 40000, 80000])
 @pytest.mark.parametrize(
     "dtype",


### PR DESCRIPTION
The current implementation outputs results as floats even if the input was ints. We don't want that for our optimizations, see also: https://github.com/dchaley/deepcell-imaging/issues/104

but we do need to maintain it in the existing API.

Current test results:
```
16 passed, 15 xfailed in 0.57s
```

Fixes #104 