### PR TITLE
Implement method=erosion

### DIFF
--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -1,9 +1,35 @@
 import numpy as np
-from fasthybridreconstruct import fast_hybrid_reconstruct
+from fasthybridreconstruct import (
+    fast_hybrid_reconstruct,
+    METHOD_DILATION,
+    METHOD_EROSION,
+)
 from skimage._shared.utils import _supported_float_type
 
 
-def cython_reconstruct_wrapper(marker, mask, footprint=None, inplace=False):
+def cython_reconstruct_wrapper(
+    marker, mask, footprint=None, inplace=False, method="dilation"
+):
+    if method == "dilation":
+        method = METHOD_DILATION
+    elif method == "erosion":
+        method = METHOD_EROSION
+    else:
+        raise ValueError(
+            "Reconstruction method can be 'dilation' or 'erosion', not '%s'." % method
+        )
+
+    if method == METHOD_DILATION and np.any(marker > mask):
+        raise ValueError(
+            "Intensity of seed image must be less than that "
+            "of the mask image for reconstruction by dilation."
+        )
+    elif method == METHOD_EROSION and np.any(marker < mask):
+        raise ValueError(
+            "Intensity of seed image must be greater than that "
+            "of the mask image for reconstruction by erosion."
+        )
+
     if inplace:
         marker = marker
     else:
@@ -14,5 +40,5 @@ def cython_reconstruct_wrapper(marker, mask, footprint=None, inplace=False):
     else:
         footprint = footprint.astype(bool, copy=True)
 
-    fast_hybrid_reconstruct(marker, mask, footprint)
+    fast_hybrid_reconstruct(marker, mask, footprint, method)
     return marker

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -105,7 +105,6 @@ def test_zero_image_one_mask():
     assert_array_almost_equal(result, 0)
 
 
-@xfail(reason="method, https://github.com/dchaley/deepcell-imaging/issues/99")
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -117,12 +116,39 @@ def test_zero_image_one_mask():
         np.uint32,
         np.int64,
         np.uint64,
-        np.float16,
+        # np.float16,
         np.float32,
         np.float64,
     ],
 )
 def test_fill_hole(dtype):
+    """Test reconstruction by erosion, which should fill holes in mask."""
+    seed = np.array([[0, 8, 8, 8, 8, 8, 8, 8, 8, 0]], dtype=dtype)
+    mask = np.array([[0, 3, 6, 2, 1, 1, 1, 4, 2, 0]], dtype=dtype)
+    result = reconstruction(seed, mask, method="erosion")
+    assert result.dtype == _supported_float_type(mask.dtype)
+    expected = np.array([[0, 3, 6, 4, 4, 4, 4, 4, 2, 0]], dtype=dtype)
+    assert_array_almost_equal(result, expected)
+
+
+@xfail(reason="n dimensions, https://github.com/dchaley/deepcell-imaging/issues/118")
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.int8,
+        np.uint8,
+        np.int16,
+        np.uint16,
+        np.int32,
+        np.uint32,
+        np.int64,
+        np.uint64,
+        # np.float16,
+        np.float32,
+        np.float64,
+    ],
+)
+def test_fill_hole_1d(dtype):
     """Test reconstruction by erosion, which should fill holes in mask."""
     seed = np.array([0, 8, 8, 8, 8, 8, 8, 8, 8, 0], dtype=dtype)
     mask = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0], dtype=dtype)
@@ -132,7 +158,6 @@ def test_fill_hole(dtype):
     assert_array_almost_equal(result, expected)
 
 
-@xfail(reason="method, https://github.com/dchaley/deepcell-imaging/issues/99")
 def test_invalid_seed():
     seed = np.ones((5, 5))
     mask = np.ones((5, 5))


### PR DESCRIPTION
Implements the erosion method, which is the inverse of dilation (flip min/max).

This revealed the need for: #119 

To workaround the 1d test, I just converted it to a 1-row 2d array… 😓 

Furthermore: the tests exercise lots of types, the not-in-place version of this actually converts the image to float no matter what, and also treats the mask as float (b/c it assigns the mask into the float array).

There's gotta be a better way to handle this than to generate all permutations of mask/marker types. The cythonize command takes nearly a minute. Maybe that's just the deal for blazing performance. Or maybe we only enable this for matching marker & mask types? We have to verify anyhow that it's an array shape we support. (to pick which algorithm)

Fixes #99 