### PR TITLE
Create container with dependencies installed

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,13 @@
+FROM us-docker.pkg.dev/deeplearning-platform-release/gcr.io/tf2-gpu.2-8.py37
+
+# The google special container is:
+# us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-gpu.2-8:latest
+#
+# See also:
+# https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime#available_container_images
+
+RUN git clone https://github.com/dchaley/deepcell-imaging.git
+
+WORKDIR "/deepcell-imaging"
+
+RUN pip install --user --upgrade --quiet -r requirements.txt


### PR DESCRIPTION
This sets up a container that executes the steps in the benchmark setup notebook. It checks out the repo so in principle we could run the notebook however we haven't tried that yet.

Followed instructions here: https://cloud.google.com/deep-learning-containers/docs/derivative-container plus,

```
export IMAGE_NAME="${LOCATION}-docker.pkg.dev/${PROJECT}/${REPOSITORY_NAME}/benchmarking:v1"
export LOCATION="us-west1"
export REPOSITORY_NAME="deepcell-benchmarking"
```

I guess we change `v1` to `v2` on next push…?

Paired with @WeihaoGe1009 

Fixes #119 

![Screenshot 2024-01-24 at 3 23 06 PM](https://github.com/dchaley/deepcell-imaging/assets/352005/8bf59557-4012-4bdf-8619-99ace7af9256)
