### PR TITLE
Add github version.json to docker image to skip cache

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -6,6 +6,9 @@ FROM us-docker.pkg.dev/deeplearning-platform-release/gcr.io/tf2-gpu.2-8.py37
 # See also:
 # https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime#available_container_images
 
+
+ADD https://api.github.com/repos/dchaley/deepcell-imaging/git/refs/heads/main version.json
+
 RUN git clone https://github.com/dchaley/deepcell-imaging.git
 
 WORKDIR "/deepcell-imaging"


### PR DESCRIPTION
This will be different each time the main branch changes. So, we can use the cached base image while rebuilding from main.

Surely there's a better way to have these huge base images cached?