### PR TITLE
Support reconstruct parameter: offset

### DIFF
--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -8,7 +8,7 @@ from skimage._shared.utils import _supported_float_type
 
 
 def cython_reconstruct_wrapper(
-    marker, mask, footprint=None, inplace=False, method="dilation"
+    marker, mask, method="dilation", footprint=None, offset=None, inplace=False
 ):
     if method == "dilation":
         method = METHOD_DILATION
@@ -30,15 +30,45 @@ def cython_reconstruct_wrapper(
             "of the mask image for reconstruction by erosion."
         )
 
+    if footprint is None:
+        footprint = np.ones([3] * marker.ndim, dtype=np.uint8)
+    else:
+        footprint = footprint.astype(np.uint8, copy=True)
+
+    if offset is None:
+        if not all([d % 2 == 1 for d in footprint.shape]):
+            raise ValueError("Footprint dimensions must all be odd")
+        offset = np.array([d // 2 for d in footprint.shape])
+    else:
+        if offset.ndim != footprint.ndim:
+            raise ValueError("Offset and footprint ndims must be equal.")
+        if not all([(0 <= o < d) for o, d in zip(offset, footprint.shape)]):
+            raise ValueError("Offset must be included inside footprint")
+
     if inplace:
         marker = marker
     else:
         marker = marker.astype(_supported_float_type(mask.dtype), copy=True)
 
-    if footprint is None:
-        footprint = np.ones((3, 3), dtype=bool)
-    else:
-        footprint = footprint.astype(bool, copy=True)
+    # The existing skimage code is inconsistent in how it creates the offset.
+    # See the offset is None block: it creates offsets of different shapes.
+    # The default offset only has 1 dimension (a list of coordinates), but
+    # a provided offset must have the same dimensions as the footprint,
+    # shaped as a single element in each dimension.
+    # Somehow, it all still works.🤔
+    #
+    # But I couldn't figure out how to pass a C reference to the data.
+    # This creates a new bytes buffer, using the contiguous array data.
+    # Cython knows how to wire this into a pointer for the C function.
+    # When we support n-dimensions and need to figure out pointers for
+    # all types, remove this…
+    offset_bytes = bytes(offset.astype(np.uint8, copy=True))
 
-    fast_hybrid_reconstruct(marker, mask, footprint, method)
+    fast_hybrid_reconstruct(
+        marker=marker,
+        mask=mask,
+        footprint=footprint,
+        method=method,
+        offset=offset_bytes,
+    )
     return marker

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -10,6 +10,8 @@ from libc.stdint cimport uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, 
 
 # This fast-hybrid reconstruction algorithm supports the following data types.
 # Adding more should be a simple matter of adding them to this list.
+
+# Production mode types
 ctypedef fused marker_dtype:
     int8_t
     uint8_t
@@ -33,6 +35,16 @@ ctypedef fused mask_dtype:
     float
     double
 
+# Dev mode types
+# ctypedef fused marker_dtype:
+#     uint8_t
+#     int64_t
+#     double
+# ctypedef fused mask_dtype:
+#     uint8_t
+#     int64_t
+#     double
+
 cpdef enum:
     METHOD_DILATION = 0
     METHOD_EROSION = 1
@@ -44,6 +56,7 @@ cdef marker_dtype get_neighborhood_peak(
     Py_ssize_t point_row,
     Py_ssize_t point_col,
     uint8_t[:, ::1] footprint,
+    uint8_t* offset,
     marker_dtype border_value,
     uint8_t method,
 ):
@@ -63,6 +76,7 @@ cdef marker_dtype get_neighborhood_peak(
       point_row (Py_ssize_t): the row of the point to scan
       point_col (Py_ssize_t): the column of the point to scan
       footprint (uint8_t[][]): the neighborhood footprint
+      offset (uint8_t*): the offset of the footprint center. Pointer to a contiguous array.
       border_value (my_type): the value to use for out-of-bound points
       method (uint8_t): METHOD_DILATION or METHOD_EROSION
 
@@ -78,8 +92,8 @@ cdef marker_dtype get_neighborhood_peak(
     cdef Py_ssize_t image_rows = image.shape[0]
     cdef Py_ssize_t image_cols = image.shape[1]
 
-    cdef Py_ssize_t footprint_center_row = footprint.shape[0] // 2
-    cdef Py_ssize_t footprint_center_col = footprint.shape[1] // 2
+    cdef Py_ssize_t footprint_center_row = offset[0]
+    cdef Py_ssize_t footprint_center_col = offset[1]
 
     for footprint_row_offset in range(-footprint_center_row, footprint_center_row + 1):
         for footprint_col_offset in range(
@@ -199,6 +213,7 @@ def fast_hybrid_raster_scans(
     uint8_t[:, ::1] footprint_raster_before,
     uint8_t[:, ::1] footprint_raster_after,
     uint8_t[:, ::1] footprint_propagation_test,
+    uint8_t* offset,
     marker_dtype border_value,
     queue,
     uint8_t method,
@@ -221,6 +236,7 @@ def fast_hybrid_raster_scans(
         footprint_raster_before (uint8_t[][]): the raster footprint before the center point
         footprint_raster_after (uint8_t[][]): the raster footprint after the center point
         footprint_propagation_test (uint8_t[][]): the raster footprint after the center point, excluding the center point
+        offset (uint8_t*): the offset of the footprint center. Pointer to a contiguous array.
         border_value (my_type): the value to use for out-of-bound points
         queue (deque): the queue of points to process
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
@@ -253,6 +269,7 @@ def fast_hybrid_raster_scans(
                 row,
                 col,
                 footprint_raster_before,
+                offset,
                 border_value,
                 method,
             )
@@ -278,6 +295,7 @@ def fast_hybrid_raster_scans(
                     row,
                     col,
                     footprint_raster_after,
+                    offset,
                     border_value,
                     method,
                 )
@@ -479,6 +497,7 @@ def fast_hybrid_reconstruct(
         footprint_raster_before,
         footprint_raster_after,
         footprint_propagation_test,
+        offset,
         border_value,
         queue,
         method,

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -17,7 +17,13 @@ xfail = pytest.mark.xfail
 
 def test_zeros():
     """Test reconstruction with image and mask of zeros"""
+
+    # With & without explicit offset
     assert_array_almost_equal(reconstruction(np.zeros((5, 7)), np.zeros((5, 7))), 0)
+    assert_array_almost_equal(
+        reconstruction(np.zeros((5, 7)), np.zeros((5, 7)), offset=np.array([[1], [1]])),
+        0,
+    )
 
 
 def test_image_equals_mask():
@@ -177,7 +183,6 @@ def test_invalid_footprint():
     reconstruction(seed, mask, footprint=np.ones((3, 3)))
 
 
-@xfail(reason="method, https://github.com/dchaley/deepcell-imaging/issues/99")
 def test_invalid_method():
     seed = np.array([0, 8, 8, 8, 8, 8, 8, 8, 8, 0])
     mask = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0])
@@ -185,7 +190,6 @@ def test_invalid_method():
         reconstruction(seed, mask, method="foo")
 
 
-@xfail(reason="offset, https://github.com/dchaley/deepcell-imaging/issues/100")
 def test_invalid_offset_not_none():
     """Test reconstruction with invalid not None offset parameter"""
     image = np.array(
@@ -218,9 +222,8 @@ def test_invalid_offset_not_none():
         )
 
 
-@xfail(reason="method, https://github.com/dchaley/deepcell-imaging/issues/99")
-@xfail(reason="offset, https://github.com/dchaley/deepcell-imaging/issues/100")
-def test_offset_not_none():
+@xfail(reason="n dimensions, https://github.com/dchaley/deepcell-imaging/issues/118")
+def test_offset_not_none_1d():
     """Test reconstruction with valid offset parameter"""
     seed = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0])
     mask = np.array([0, 8, 6, 8, 8, 8, 8, 4, 4, 0])
@@ -229,6 +232,25 @@ def test_offset_not_none():
     assert_array_almost_equal(
         reconstruction(
             seed, mask, method="dilation", footprint=np.ones(3), offset=np.array([0])
+        ),
+        expected,
+    )
+
+
+@xfail(reason="offset, https://github.com/dchaley/deepcell-imaging/issues/100")
+def test_offset_not_none():
+    """Test reconstruction with valid offset parameter"""
+    seed = np.array([[0, 3, 6, 2, 1, 1, 1, 4, 2, 0]])
+    mask = np.array([[0, 8, 6, 8, 8, 8, 8, 4, 4, 0]])
+    expected = np.array([[0, 3, 6, 6, 6, 6, 6, 4, 4, 0]])
+
+    assert_array_almost_equal(
+        reconstruction(
+            seed,
+            mask,
+            method="dilation",
+            footprint=np.array([[1, 1, 1]]),
+            offset=np.array([[0], [0]]),
         ),
         expected,
     )

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -237,7 +237,6 @@ def test_offset_not_none_1d():
     )
 
 
-@xfail(reason="offset, https://github.com/dchaley/deepcell-imaging/issues/100")
 def test_offset_not_none():
     """Test reconstruction with valid offset parameter"""
     seed = np.array([[0, 3, 6, 2, 1, 1, 1, 4, 2, 0]])


### PR DESCRIPTION
Implement the footprint offset parameter, which allows centering the footprint on a point other than the center.

Along the way, clean up a few now-passing `xfail`s.

Fixes #100 