### PR TITLE
Parameterize offset in OpenCV chaos testing

### DIFF
--- a/benchmarking/h_maxima/benchmark_utils.py
+++ b/benchmarking/h_maxima/benchmark_utils.py
@@ -19,7 +19,12 @@ def opencv_reconstruct(
     # .item() converts the numpy scalar to a python scalar
     pad_value = np.min(marker).item()
 
-    if not kernel[kernel.shape[0] // 2, kernel.shape[1] // 2]:
+    if anchor == (-1, -1):
+        # OpenCV uses (x, y) not (row, col) for the anchor
+        anchor = (kernel.shape[1] // 2, kernel.shape[0] // 2)
+
+    # The kernel however uses rows/cols not x/y…
+    if not kernel[anchor[1], anchor[0]]:
         raise ValueError("The center of the kernel must be True")
 
     while True:

--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -42,7 +42,7 @@ def cython_reconstruct_wrapper(
     else:
         if offset.ndim != footprint.ndim:
             raise ValueError("Offset and footprint ndims must be equal.")
-        if not all([(0 <= o < d) for o, d in zip(offset, footprint.shape)]):
+        if not all([(0 <= o < d) for o, d in zip(offset[0], footprint.shape)]):
             raise ValueError("Offset must be included inside footprint")
 
     if inplace:

--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -40,9 +40,9 @@ def cython_reconstruct_wrapper(
             raise ValueError("Footprint dimensions must all be odd")
         offset = np.array([d // 2 for d in footprint.shape])
     else:
-        if offset.ndim != footprint.ndim:
-            raise ValueError("Offset and footprint ndims must be equal.")
-        if not all([(0 <= o < d) for o, d in zip(offset[0], footprint.shape)]):
+        if offset.shape[0] != footprint.ndim:
+            raise ValueError("Offset length and footprint ndims must be equal.")
+        if not all([(0 <= o < d) for o, d in zip(offset, footprint.shape)]):
             raise ValueError("Offset must be included inside footprint")
 
     if inplace:
@@ -62,13 +62,13 @@ def cython_reconstruct_wrapper(
     # Cython knows how to wire this into a pointer for the C function.
     # When we support n-dimensions and need to figure out pointers for
     # all types, remove this…
-    offset_bytes = bytes(offset.astype(np.uint8, copy=True))
+    offset = offset.astype(np.uint8, copy=True)
 
     fast_hybrid_reconstruct(
         marker=marker,
         mask=mask,
         footprint=footprint,
         method=method,
-        offset=offset_bytes,
+        offset=offset,
     )
     return marker

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -58,7 +58,7 @@ cdef marker_dtype get_neighborhood_peak(
     Py_ssize_t point_row,
     Py_ssize_t point_col,
     uint8_t[:, ::1] footprint,
-    uint8_t* offset,
+    uint8_t[::1] offset,
     marker_dtype border_value,
     uint8_t method,
 ):
@@ -78,7 +78,7 @@ cdef marker_dtype get_neighborhood_peak(
       point_row (Py_ssize_t): the row of the point to scan
       point_col (Py_ssize_t): the column of the point to scan
       footprint (uint8_t[][]): the neighborhood footprint
-      offset (uint8_t*): the offset of the footprint center. Pointer to a contiguous array.
+      offset (uint8_t[]): the offset of the footprint center.
       border_value (my_type): the value to use for out-of-bound points
       method (uint8_t): METHOD_DILATION or METHOD_EROSION
 
@@ -100,6 +100,7 @@ cdef marker_dtype get_neighborhood_peak(
     for offset_row in range(-footprint_center_row, footprint.shape[0] - footprint_center_row):
         for offset_col in range(-footprint_center_col, footprint.shape[1] - footprint_center_col):
             # Skip this point if not in the footprint, and not the center point.
+            # (The center point is always included in the neighborhood.)
             if (not footprint[footprint_center_row + offset_row, footprint_center_col + offset_col]
                     and not (offset_row == 0 and offset_col == 0)):
                 continue
@@ -133,7 +134,7 @@ cdef uint8_t should_propagate(
     Py_ssize_t point_col,
     marker_dtype point_value,
     uint8_t[:, ::1] footprint,
-    uint8_t* offset,
+    uint8_t[::1] offset,
     uint8_t method,
 ):
     """Determine if a point should be propagated to its neighbors.
@@ -153,7 +154,7 @@ cdef uint8_t should_propagate(
         point_col (Py_ssize_t): the column of the point to scan
         point_value (marker_dtype): the value of the point to scan
         footprint (uint8_t[][]): the neighborhood footprint
-        offset (uint8_t*): the offset of the footprint center. Pointer to a contiguous array.
+        offset (uint8_t[]): the offset of the footprint center.
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
 
     Returns:
@@ -215,7 +216,7 @@ def fast_hybrid_raster_scans(
     uint8_t[:, ::1] footprint_raster_before,
     uint8_t[:, ::1] footprint_raster_after,
     uint8_t[:, ::1] footprint_propagation_test,
-    uint8_t* offset,
+    uint8_t[::1] offset,
     marker_dtype border_value,
     queue,
     uint8_t method,
@@ -238,7 +239,7 @@ def fast_hybrid_raster_scans(
         footprint_raster_before (uint8_t[][]): the raster footprint before the center point
         footprint_raster_after (uint8_t[][]): the raster footprint after the center point
         footprint_propagation_test (uint8_t[][]): the raster footprint after the center point, excluding the center point
-        offset (uint8_t*): the offset of the footprint center. Pointer to a contiguous array.
+        offset (uint8_t[]): the offset of the footprint center.
         border_value (my_type): the value to use for out-of-bound points
         queue (deque): the queue of points to process
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
@@ -321,7 +322,7 @@ def process_queue(
    marker_dtype[:, ::1] marker,
    mask_dtype[:, ::1] mask,
    uint8_t[:, ::1] footprint,
-   uint8_t* offset,
+   uint8_t[::1] offset,
    queue,
    uint8_t method,
 ):
@@ -338,7 +339,7 @@ def process_queue(
         marker (mytype[][]): the marker image to scan
         mask (mytype[][]): the image mask (ceiling on image values)
         footprint (uint8_t[][]): the neighborhood footprint
-        offset (uint8_t*): the offset of the footprint center. Pointer to a contiguous array.
+        offset (uint8_t[]): the offset of the footprint center.
         queue (deque): the queue of points to process
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
     """
@@ -404,7 +405,7 @@ def fast_hybrid_reconstruct(
         mask_dtype[:, ::1] mask,
         uint8_t[:, ::1] footprint,
         uint8_t method,
-        uint8_t* offset
+        uint8_t[::1] offset
 ):
     """Perform grayscale reconstruction using the 'Fast-Hybrid' algorithm.
 
@@ -434,7 +435,7 @@ def fast_hybrid_reconstruct(
         mask (my_type[][]): the mask image
         footprint (uint8_t[][]): the neighborhood footprint aka N(G)
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
-        offset (uint8_t*): the offset of the footprint center. Pointer to a contiguous array.
+        offset (uint8_t[]): the offset of the footprint center.
 
     Returns:
         my_type[][]: the reconstructed marker image, modified in place
@@ -484,10 +485,7 @@ def fast_hybrid_reconstruct(
     #
     # However, an asymmetric footprint doesn't have this property.
     # TODO: I think we only need to check N- because we're scanning back to N+ anyhow
-    #
-    # Also, the center point isn't considered its own neighbor.
     footprint_propagation_test = np.copy(footprint)
-    footprint_propagation_test[footprint_center_row, footprint_center_col] = 0
 
     # .item() converts the numpy scalar to a python scalar
     if method == METHOD_DILATION:

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -166,21 +166,22 @@ cdef uint8_t should_propagate(
     cdef Py_ssize_t image_cols = image.shape[1]
     cdef Py_ssize_t footprint_center_row = offset[0]
     cdef Py_ssize_t footprint_center_col = offset[1]
-    cdef Py_ssize_t offset_row, offset_col
+    cdef Py_ssize_t footprint_row, footprint_col
 
-    for offset_row in range(-footprint_center_row, footprint.shape[0] - footprint_center_row):
-        for offset_col in range(-footprint_center_col, footprint.shape[1] - footprint_center_col):
+    # Place the current point at each position of the footprint.
+    # If that footprint position is true, then, the current point
+    # is a neighbor of the footprint center.
+    for footprint_row in range(0, footprint.shape[0]):
+        for footprint_col in range(0, footprint.shape[1]):
             # The center point is always skipped.
             # Also skip if not in footprint.
-            # Note: we are testing *reverse neighbors* (see minus sign).
-            # Because we want to see if we are a neighbor of that point,
-            # to know if that point might "pull in" our value.
-            if ((offset_row == 0 and offset_col == 0)
-                    or not footprint[footprint_center_row - offset_row, footprint_center_col - offset_col]):
+            if ((footprint_row == offset[0] and footprint_col == offset[1])
+                    or not footprint[footprint_row, footprint_col]):
                 continue
 
-            neighbor_row = point_row + offset_row
-            neighbor_col = point_col + offset_col
+            # The center point is the current point, offset by the footprint center.
+            neighbor_row = point_row + (footprint_center_row - footprint_row)
+            neighbor_col = point_col + (footprint_center_col - footprint_col)
 
             # Skip out of bounds
             if (
@@ -344,7 +345,7 @@ def process_queue(
     cdef Py_ssize_t marker_rows = marker.shape[0]
     cdef Py_ssize_t marker_cols = marker.shape[1]
     cdef Py_ssize_t row, col
-    cdef Py_ssize_t offset_row, offset_col
+    cdef Py_ssize_t footprint_row, footprint_col
     cdef Py_ssize_t neighbor_row, neighbor_col
     cdef marker_dtype neighbor_mask
     cdef marker_dtype neighbor_value, point_value
@@ -360,19 +361,20 @@ def process_queue(
         col = point[1]
         point_value = marker[row, col]
 
-        for offset_row in range(-footprint_center_row, footprint.shape[0] - footprint_center_row):
-            for offset_col in range(-footprint_center_col, footprint.shape[1] - footprint_center_col):
+        # Place the current point at each position of the footprint.
+        # If that footprint position is true, then, the current point
+        # is a neighbor of the footprint center.
+        for footprint_row in range(0, footprint.shape[0]):
+            for footprint_col in range(0, footprint.shape[1]):
                 # The center point is always skipped.
                 # Also skip if not in footprint.
-                # Note: we are testing *reverse neighbors* (see minus sign).
-                # Because we want to see if we are a neighbor of that point,
-                # to know if that point might "pull in" our value.
-                if ((offset_row == 0 and offset_col == 0)
-                        or not footprint[footprint_center_row - offset_row, footprint_center_col - offset_col]):
+                if ((footprint_row == offset[0] and footprint_col == offset[1])
+                        or not footprint[footprint_row, footprint_col]):
                     continue
 
-                neighbor_row = row + offset_row
-                neighbor_col = col + offset_col
+                # The center point is the current point, offset by the footprint center.
+                neighbor_row = row + (footprint_center_row - footprint_row)
+                neighbor_col = col + (footprint_center_col - footprint_col)
 
                 if (
                         neighbor_row < 0

--- a/benchmarking/h_maxima/test_opencv_comparison.py
+++ b/benchmarking/h_maxima/test_opencv_comparison.py
@@ -32,11 +32,11 @@ xfail = pytest.mark.xfail
 # )
 @pytest.mark.parametrize(
     "rows",
-    [10, 100, 1000],
+    [11, 96, 1023],
 )
 @pytest.mark.parametrize(
     "cols",
-    [10, 100, 1000],
+    [15, 130, 999],
 )
 @pytest.mark.parametrize(
     "method",

--- a/benchmarking/h_maxima/test_opencv_comparison.py
+++ b/benchmarking/h_maxima/test_opencv_comparison.py
@@ -32,11 +32,11 @@ xfail = pytest.mark.xfail
 # )
 @pytest.mark.parametrize(
     "rows",
-    [11, 96, 1023],
+    [3, 11, 96, 1023],
 )
 @pytest.mark.parametrize(
     "cols",
-    [15, 130, 999],
+    [3, 15, 130, 999],
 )
 @pytest.mark.parametrize(
     "method",

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -412,3 +412,56 @@ def test_arbitrary_5x5():
         fast_hybrid_result,
         expected,
     )
+
+
+def test_arbitrary_3x3_offset():
+    seed = np.array(
+        [
+            [19966, 12875, -17043],
+            [13956, -4738, -14016],
+            [-15038, -4688, 28636],
+        ],
+        dtype=np.int16,
+    )
+    mask = np.array(
+        [
+            [21602, 12875, 30438],
+            [13956, -4738, 14362],
+            [-15038, 14383, 30826],
+        ],
+        dtype=np.int16,
+    )
+    footprint = np.array(
+        [
+            [1, 0, 0],
+            [0, 1, 0],
+            [1, 1, 1],
+        ],
+        dtype=np.uint8,
+    )
+    # Proof of work following iterations of parallel method:
+    # (repeat point-wise maximum filtered min-wise with mask, until convergence)
+    # https://docs.google.com/spreadsheets/d/15TntEi694OUy3ZjAdAdY2Ax6FTdCsCXiqGfpxpV7-iY/edit#gid=1863474562
+    expected = np.array(
+        [
+            [19966, 12875, 19966],
+            [13956, -4738, 13956],
+            [-15038, 13956, 28636],
+        ],
+        dtype=np.int16,
+    )
+
+    offset = np.array([[2], [2]])
+
+    fast_hybrid_result = reconstruction(
+        np.ndarray.copy(seed),
+        np.ndarray.copy(mask),
+        method="dilation",
+        footprint=np.ndarray.copy(footprint),
+        offset=offset,
+    )
+
+    assert_array_almost_equal(
+        fast_hybrid_result,
+        expected,
+    )

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -465,3 +465,58 @@ def test_arbitrary_3x3_offset():
         fast_hybrid_result,
         expected,
     )
+
+
+def test_arbitrary_3x3_offset_5x3_footprint():
+    seed = np.array(
+        [
+            [254, 205, 75],
+            [178, 109, 61],
+            [132, 182, 126],
+        ],
+        dtype=np.uint8,
+    )
+    mask = np.array(
+        [
+            [254, 205, 176],
+            [178, 220, 239],
+            [132, 182, 126],
+        ],
+        dtype=np.uint8,
+    )
+    footprint = np.array(
+        [
+            [0, 0, 1],
+            [1, 1, 0],
+            [0, 0, 1],
+            [0, 1, 0],
+            [0, 0, 1],
+        ],
+        dtype=np.uint8,
+    )
+    # Proof of work following iterations of parallel method:
+    # (repeat point-wise maximum filtered min-wise with mask, until convergence)
+    # https://docs.google.com/spreadsheets/d/15TntEi694OUy3ZjAdAdY2Ax6FTdCsCXiqGfpxpV7-iY/edit#gid=1552794151
+    expected = np.array(
+        [
+            [254, 205, 176],
+            [178, 132, 182],
+            [132, 182, 126],
+        ],
+        dtype=np.uint8,
+    )
+
+    offset = np.array([[2], [2]])
+
+    fast_hybrid_result = reconstruction(
+        np.ndarray.copy(seed),
+        np.ndarray.copy(mask),
+        method="dilation",
+        footprint=np.ndarray.copy(footprint),
+        offset=offset,
+    )
+
+    assert_array_almost_equal(
+        fast_hybrid_result,
+        expected,
+    )

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -506,7 +506,7 @@ def test_arbitrary_3x3_offset_5x3_footprint():
         dtype=np.uint8,
     )
 
-    offset = np.array([[2], [2]])
+    offset = np.array([[0], [2]])
 
     fast_hybrid_result = reconstruction(
         np.ndarray.copy(seed),

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -23,7 +23,7 @@ def test_zeros():
     # With & without explicit offset
     assert_array_almost_equal(reconstruction(np.zeros((5, 7)), np.zeros((5, 7))), 0)
     assert_array_almost_equal(
-        reconstruction(np.zeros((5, 7)), np.zeros((5, 7)), offset=np.array([[1], [1]])),
+        reconstruction(np.zeros((5, 7)), np.zeros((5, 7)), offset=np.array([1, 1])),
         0,
     )
 
@@ -251,7 +251,7 @@ def test_offset_not_none():
             mask,
             method="dilation",
             footprint=np.array([[1, 1, 1]]),
-            offset=np.array([[0], [0]]),
+            offset=np.array([0, 0]),
         ),
         expected,
     )
@@ -451,13 +451,13 @@ def test_arbitrary_3x3_offset():
         dtype=np.int16,
     )
 
-    offset = np.array([[2], [2]])
+    offset = np.array([2, 2])
 
     fast_hybrid_result = reconstruction(
-        np.ndarray.copy(seed),
-        np.ndarray.copy(mask),
+        seed.copy(),
+        mask.copy(),
         method="dilation",
-        footprint=np.ndarray.copy(footprint),
+        footprint=footprint.copy(),
         offset=offset,
     )
 
@@ -506,7 +506,7 @@ def test_arbitrary_3x3_offset_5x3_footprint():
         dtype=np.uint8,
     )
 
-    offset = np.array([[0], [2]])
+    offset = np.array([0, 2])
 
     fast_hybrid_result = reconstruction(
         np.ndarray.copy(seed),


### PR DESCRIPTION
This PR extends the OpenCV chaos testing by parameterizing the offset (or anchor point) in the footprint. In other words, randomize footprints, and also randomize which point is the center. This illuminates interesting edge cases around asymmetry. 🙃 

I identified bugs by parameterizing the comparison. I formalized those specific tests in `test_reconstruction.py`, deriving the expectations by hand in [this spreadsheet](https://docs.google.com/spreadsheets/d/15TntEi694OUy3ZjAdAdY2Ax6FTdCsCXiqGfpxpV7-iY/edit#gid=1552794151). I changed the code until the tests passed … and kept doing that until I stopped finding bugs.

One of the bugs was an interesting heisenbug, commit [c3b0028](https://github.com/dchaley/deepcell-imaging/commit/c3b00282ee48250f99746ee5363a45b6a4a5133b) fixed an out-of-bounds error. I saw tests succeed & fail non-deterministically on the same input data, I turned bounds checking back on and saw some things were wrong. This was helpful as it highlighted some errors 😎 

After a few rounds I committed the comparison test itself.

Fixes #138 