### PR TITLE
Default batch size 16; parameter to skip postprocessing (results unintelligible)

### DIFF
--- a/benchmarking/deepcell-e2e/benchmark.ipynb
+++ b/benchmarking/deepcell-e2e/benchmark.ipynb
@@ -98,7 +98,7 @@
     "sys.modules[module_name] = module\n",
     "spec.loader.exec_module(module)\n",
     "\n",
-    "from deepcell_imaging import cached_open"
+    "from deepcell_imaging import cached_open, mesmer_no_postprocess"
    ]
   },
   {
@@ -144,7 +144,7 @@
     "# Default: 4.\n",
     "# DeepCell divides each image into tiles, predicts in batches,\n",
     "# then untiles the result to return overall segmentat predictions.\n",
-    "batch_size = 4\n",
+    "batch_size = 16\n",
     "\n",
     "# The location of the TensorFlow model to download.\n",
     "# The tarball needs to extract to the directory: 'MultiplexSegmentation'\n",
@@ -161,6 +161,9 @@
     "location = 'us-west1'\n",
     "# Set to None for local execution.\n",
     "notebook_runtime_id = 'updateme'\n",
+    "\n",
+    "# Set this to true to skip DeepCell's postprocessing (h_maxima, floodfill, etc)\n",
+    "skip_postprocessing = False\n",
     "\n",
     "# Set this to True to visualize & save input & prediction.\n",
     "# If true, the paths may be provided to save the visualizations to storage.\n",
@@ -192,7 +195,7 @@
      "output_type": "stream",
      "text": [
       "INFO:root:Loading model from /Users/davidhaley/.keras/models/MultiplexSegmentation.\n",
-      "2024-01-08 19:27:23.949711: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
+      "2024-03-06 13:52:33.801778: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
       "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n"
      ]
     },
@@ -208,7 +211,7 @@
      "output_type": "stream",
      "text": [
       "WARNING:tensorflow:No training configuration found in save file, so the model was *not* compiled. Compile it manually.\n",
-      "INFO:root:Loaded model in 26.04440486000385 s\n"
+      "INFO:root:Loaded model in 35.1317582228221 s\n"
      ]
     }
    ],
@@ -238,7 +241,10 @@
     "    model = tf.keras.models.load_model(model_path)\n",
     "    logging.info(\"Loaded model in %s s\" % (timeit.default_timer() - t))\n",
     "finally:\n",
-    "    app = Mesmer(model=model)\n",
+    "    if skip_postprocessing:\n",
+    "        app = mesmer_no_postprocess.MesmerNoPostprocess(model=model)\n",
+    "    else:\n",
+    "        app = Mesmer(model=model)\n",
     "    pass\n",
     "    \n",
     "# Need to reset top-level logging for intercept to work.\n",
@@ -268,31 +274,31 @@
      "output_type": "stream",
      "text": [
       "DEBUG:Mesmer:Pre-processing data with mesmer_preprocess and kwargs: {}\n",
-      "DEBUG:Mesmer:Pre-processed data with mesmer_preprocess in 0.09573872399050742 s\n"
+      "DEBUG:Mesmer:Pre-processed data with mesmer_preprocess in 0.1485789509024471 s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded input in 4.423365914000897 s\n"
+      "Loaded input in 5.795006005093455 s\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "DEBUG:Mesmer:Model inference finished in 5.439006330998382 s\n",
+      "DEBUG:Mesmer:Model inference finished in 7.146363381063566 s\n",
       "DEBUG:Mesmer:Post-processing results with mesmer_postprocess and kwargs: {'whole_cell_kwargs': {'maxima_threshold': 0.075, 'maxima_smooth': 0, 'interior_threshold': 0.2, 'interior_smooth': 2, 'small_objects_threshold': 15, 'fill_holes_threshold': 15, 'radius': 2}, 'nuclear_kwargs': {'maxima_threshold': 0.1, 'maxima_smooth': 0, 'interior_threshold': 0.2, 'interior_smooth': 2, 'small_objects_threshold': 15, 'fill_holes_threshold': 15, 'radius': 2}, 'compartment': 'whole-cell'}\n",
-      "DEBUG:Mesmer:Post-processed results with mesmer_postprocess in 0.3438746779866051 s\n"
+      "DEBUG:Mesmer:Post-processed results with mesmer_postprocess in 0.4427078948356211 s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Prediction finished in 5.9581321839941666 s\n",
-      "Overall operation finished in 10.382393015024718 s\n"
+      "Prediction finished in 7.848108677892014 s\n",
+      "Overall operation finished in 13.64469088986516 s\n"
      ]
     }
    ],
@@ -361,13 +367,21 @@
     "# Parse the intercepted debug logs to extract step timing.\n",
     "\n",
     "debug_logs = logs_buffer.getvalue()\n",
-    "pattern = r\"(?sm)Pre-processed data with mesmer_preprocess in (.+?) s.*Model inference finished in (.+?) s.*Post-processed results with mesmer_postprocess in (.+?) s\"\n",
+    "\n",
+    "if skip_postprocessing:\n",
+    "    pattern = r\"(?sm)Pre-processed data with mesmer_preprocess in (.+?) s.*Model inference finished in (.+?) s\"\n",
+    "else:\n",
+    "    pattern = r\"(?sm)Pre-processed data with mesmer_preprocess in (.+?) s.*Model inference finished in (.+?) s.*Post-processed results with mesmer_postprocess in (.+?) s\"\n",
+    "\n",
     "match = re.search(re.compile(pattern, re.MULTILINE), debug_logs)\n",
     "\n",
     "if match:\n",
     "    preprocess_time_s = float(match.group(1))\n",
     "    inference_time_s = float(match.group(2))\n",
-    "    postprocess_time_s = float(match.group(3))\n",
+    "    if skip_postprocessing:\n",
+    "        postprocess_time_s = float(0)\n",
+    "    else:\n",
+    "        postprocess_time_s = float(match.group(3))\n",
     "else:\n",
     "    logger.warning(\"Couldn't parse step timings from debug_logs\")\n",
     "    preprocess_time_s = inference_time_s = postprocess_time_s = math.nan"
@@ -530,8 +544,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\"Input file id\",\"Image size (MB)\",\"Pixels (M)\",\"Compartment\",\"Benchmark datetime (UTC)\",\"Machine type\",\"GPU type\",\"# GPUs\",\"Batch size\",\"Kernel\",\"Success?\",\"Total time (s)\",\"Peak memory (GB)\",\"Load time (s)\",\"Total prediction time (s)\",\"Prediction overhead (s)\",\"Predict preprocess time (s)\",\"Predict inference time (s)\",\"Predict postprocess time (s)\",\"deepcell-tf version\"\n",
-      "\"mesmer-sample-3-dev\",4.19,0.26,\"whole-cell\",\"2024-01-09 03:27:58.480992+00:00\",\"error\",\"None\",0,4,\"python3\",True,10.38,2.1,4.42,5.96,0.08,0.1,5.44,0.34,\"0.12.9\"\n",
+      "Appending benchmark result to bigquery\n",
+      "Appended result row to bigquery:\n",
+      "\"input_file_id\",\"numpy_size_mb\",\"pixels_m\",\"compartment\",\"benchmark_datetime_utc\",\"instance_type\",\"gpu_type\",\"num_gpus\",\"batch_size\",\"kernel\",\"success\",\"total_time_s\",\"peak_memory_gb\",\"load_time_s\",\"total_prediction_time_s\",\"prediction_overhead_s\",\"predict_preprocess_time_s\",\"predict_inference_time_s\",\"predict_postprocess_time_s\",\"deepcell_tf_version\",\"machine_config\",\"is_first_run\"\n",
+      "\"mesmer-sample-3-dev\",4.19,0.26,\"whole-cell\",\"2024-03-06 21:53:20.307328+00:00\",\"error\",\"None\",0,16,\"python3\",True,13.64,2.9,5.8,7.85,0.11,0.15,7.15,0.44,\"0.12.9\",\"error\",\"\"\n",
       "\n"
      ]
     }
@@ -622,7 +638,10 @@
     "writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)\n",
     "writer.writerow(headers)\n",
     "\n",
-    "deepcell_version = deepcell.__version__\n",
+    "if skip_postprocessing:\n",
+    "    deepcell_version = deepcell.__version__ + \"_nopost\"\n",
+    "else:\n",
+    "    deepcell_version = deepcell.__version__\n",
     "\n",
     "if gpu_count == 0:\n",
     "    machine_config = machine_type\n",


### PR DESCRIPTION
Update the default batch size to 16 in our benchmarking as that's the one we use most commonly.

Importantly, add the `skip_postprocessing` parameter which creates a custom Mesmer application with a no-op post-processing step. Note that this makes the results unintelligible. It's reflected in the results with a different deepcell version: `_nopost`.

Paired with @WeihaoGe1009 

Fixes #172 