### PR TITLE
Refactor memory views to pointers

### DIFF
--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -8,7 +8,7 @@ from skimage._shared.utils import _supported_float_type
 
 
 def cython_reconstruct_wrapper(
-    marker, mask, method="dilation", footprint=None, offset=None, inplace=False
+    image, mask, method="dilation", footprint=None, offset=None, inplace=False
 ):
     if method == "dilation":
         method = METHOD_DILATION
@@ -19,19 +19,19 @@ def cython_reconstruct_wrapper(
             "Reconstruction method can be 'dilation' or 'erosion', not '%s'." % method
         )
 
-    if method == METHOD_DILATION and np.any(marker > mask):
+    if method == METHOD_DILATION and np.any(image > mask):
         raise ValueError(
             "Intensity of seed image must be less than that "
             "of the mask image for reconstruction by dilation."
         )
-    elif method == METHOD_EROSION and np.any(marker < mask):
+    elif method == METHOD_EROSION and np.any(image < mask):
         raise ValueError(
             "Intensity of seed image must be greater than that "
             "of the mask image for reconstruction by erosion."
         )
 
     if footprint is None:
-        footprint = np.ones([3] * marker.ndim, dtype=np.uint8)
+        footprint = np.ones([3] * image.ndim, dtype=np.uint8)
     else:
         footprint = footprint.astype(np.uint8, copy=True)
 
@@ -46,9 +46,9 @@ def cython_reconstruct_wrapper(
             raise ValueError("Offset must be included inside footprint")
 
     if inplace:
-        marker = marker
+        image = image
     else:
-        marker = marker.astype(_supported_float_type(mask.dtype), copy=True)
+        image = image.astype(_supported_float_type(mask.dtype), copy=True)
 
     # The existing skimage code is inconsistent in how it creates the offset.
     # See the offset is None block: it creates offsets of different shapes.
@@ -65,10 +65,10 @@ def cython_reconstruct_wrapper(
     offset = offset.astype(np.uint8, copy=True)
 
     fast_hybrid_reconstruct(
-        marker=marker,
+        image=image,
         mask=mask,
         footprint=footprint,
         method=method,
         offset=offset,
     )
-    return marker
+    return image

--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -52,9 +52,18 @@ def cython_reconstruct_wrapper(
             raise ValueError("Offset must be included inside footprint")
 
     if inplace:
-        image = image
+        if image.dtype != mask.dtype:
+            raise ValueError("in-place reconstruct requires same type for image & mask")
     else:
-        image = image.astype(_supported_float_type(mask.dtype), copy=True)
+        # I'm not sure that we need to do this. Why add floating
+        # point precision that wasn't there in the first place?
+        normalized_type = _supported_float_type(mask.dtype)
+        # Always copy the image, so we're not changing in-place.
+        image = image.astype(normalized_type, copy=True)
+        # Only copy the mask if it's not the right type.
+        # We don't write to the mask.
+        if mask.dtype != normalized_type:
+            mask = mask.astype(normalized_type, copy=True)
 
     offset = offset.astype(np.uint8, copy=True)
 

--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -35,13 +35,19 @@ def cython_reconstruct_wrapper(
     else:
         footprint = footprint.astype(np.uint8, copy=True)
 
+    # The existing skimage code is inconsistent in how it creates the offset.
+    # See the offset is None block: it creates offsets of different shapes.
+    # The default offset only has 1 dimension (a list of coordinates), but
+    # a provided offset must have the same dimensions as the footprint,
+    # shaped as a single element in each dimension.
     if offset is None:
         if not all([d % 2 == 1 for d in footprint.shape]):
             raise ValueError("Footprint dimensions must all be odd")
         offset = np.array([d // 2 for d in footprint.shape])
     else:
-        if offset.shape[0] != footprint.ndim:
-            raise ValueError("Offset length and footprint ndims must be equal.")
+        # Unlike skimage, make sure we have with 1 value per footprint dimension
+        if offset.shape != (footprint.ndim,):
+            raise ValueError("Offset must be of shape[footprint.ndim,].")
         if not all([(0 <= o < d) for o, d in zip(offset, footprint.shape)]):
             raise ValueError("Offset must be included inside footprint")
 
@@ -50,18 +56,6 @@ def cython_reconstruct_wrapper(
     else:
         image = image.astype(_supported_float_type(mask.dtype), copy=True)
 
-    # The existing skimage code is inconsistent in how it creates the offset.
-    # See the offset is None block: it creates offsets of different shapes.
-    # The default offset only has 1 dimension (a list of coordinates), but
-    # a provided offset must have the same dimensions as the footprint,
-    # shaped as a single element in each dimension.
-    # Somehow, it all still works.🤔
-    #
-    # But I couldn't figure out how to pass a C reference to the data.
-    # This creates a new bytes buffer, using the contiguous array data.
-    # Cython knows how to wire this into a pointer for the C function.
-    # When we support n-dimensions and need to figure out pointers for
-    # all types, remove this…
     offset = offset.astype(np.uint8, copy=True)
 
     fast_hybrid_reconstruct(

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -71,11 +71,11 @@ cdef image_dtype get_neighborhood_peak(
       footprint_rows (Py_ssize_t): the number of rows in the footprint
       footprint_cols (Py_ssize_t): the number of columns in the footprint
       offset (uint8_t*): the offset of the footprint center.
-      border_value (my_type): the value to use for out-of-bound points
+      border_value (image_dtype): the value to use for out-of-bound points
       method (uint8_t): METHOD_DILATION or METHOD_EROSION
 
     Returns:
-        my_type: the maximum in the point's neighborhood, greater than or equal to border_value.
+        image_dtype: the maximum in the point's neighborhood, greater than or equal to border_value.
     """
     cdef image_dtype pixel_value
     # OOB values get the border value
@@ -430,14 +430,14 @@ def fast_hybrid_reconstruct(
     Note that this modifies the image in place.
 
     Args:
-        image (my_type[][]): the image
-        mask (my_type[][]): the mask image
+        image (image_dtype[][]): the image
+        mask (image_dtype[][]): the mask image
         footprint (uint8_t[][]): the neighborhood footprint aka N(G)
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
         offset (uint8_t[]): the offset of the footprint center.
 
     Returns:
-        my_type[][]: the reconstructed image, modified in place
+        image_dtype[][]: the reconstructed image, modified in place
     """
     cdef Py_ssize_t row, col
     cdef Py_ssize_t footprint_rows, footprint_cols

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -62,7 +62,7 @@ cdef image_dtype get_neighborhood_peak(
     uint8_t* footprint,
     Py_ssize_t footprint_rows,
     Py_ssize_t footprint_cols,
-    uint8_t[::1] offset,
+    uint8_t* offset,
     image_dtype border_value,
     uint8_t method,
 ):
@@ -86,7 +86,7 @@ cdef image_dtype get_neighborhood_peak(
       footprint (uint8_t*): the neighborhood footprint
       footprint_rows (Py_ssize_t): the number of rows in the footprint
       footprint_cols (Py_ssize_t): the number of columns in the footprint
-      offset (uint8_t[]): the offset of the footprint center.
+      offset (uint8_t*): the offset of the footprint center.
       border_value (my_type): the value to use for out-of-bound points
       method (uint8_t): METHOD_DILATION or METHOD_EROSION
 
@@ -276,7 +276,7 @@ def fast_hybrid_raster_scans(
                 &footprint_raster_before[0, 0],
                 footprint_raster_before.shape[0],
                 footprint_raster_before.shape[1],
-                offset,
+                &offset[0],
                 border_value,
                 method,
             )
@@ -306,7 +306,7 @@ def fast_hybrid_raster_scans(
                     &footprint_raster_after[0, 0],
                     footprint_raster_after.shape[0],
                     footprint_raster_after.shape[1],
-                    offset,
+                    &offset[0],
                     border_value,
                     method,
                 )

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -429,6 +429,7 @@ def fast_hybrid_reconstruct(
         mask_dtype[:, ::1] mask,
         uint8_t[:, ::1] footprint,
         uint8_t method,
+        # FIXME(171): offset should be a Py_ssize_t
         uint8_t[::1] offset
 ):
     """Perform grayscale reconstruction using the 'Fast-Hybrid' algorithm.

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -23,25 +23,9 @@ ctypedef fused image_dtype:
     uint64_t
     float
     double
-ctypedef fused mask_dtype:
-    int8_t
-    uint8_t
-    int16_t
-    uint16_t
-    int32_t
-    uint32_t
-    int64_t
-    uint64_t
-    float
-    double
 
 # Dev mode types
 # ctypedef fused image_dtype:
-#     uint8_t
-#     int16_t
-#     int64_t
-#     double
-# ctypedef fused mask_dtype:
 #     uint8_t
 #     int16_t
 #     int64_t
@@ -137,7 +121,7 @@ cdef uint8_t should_propagate(
     image_dtype* image,
     Py_ssize_t image_rows,
     Py_ssize_t image_cols,
-    mask_dtype* mask,
+    image_dtype* mask,
     Py_ssize_t point_row,
     Py_ssize_t point_col,
     image_dtype point_value,
@@ -161,7 +145,7 @@ cdef uint8_t should_propagate(
         image (image_dtype*): the image to scan
         image_rows (Py_ssize_t): the number of rows in the image
         image_cols (Py_ssize_t): the number of columns in the image
-        mask (mask_dtype*): the mask to apply
+        mask (image_dtype*): the mask to apply
         point_row (Py_ssize_t): the row of the point to scan
         point_col (Py_ssize_t): the column of the point to scan
         point_value (image_dtype): the value of the point to scan
@@ -226,7 +210,7 @@ cdef void perform_raster_scan(
     image_dtype* image,
     Py_ssize_t image_rows,
     Py_ssize_t image_cols,
-    mask_dtype* mask,
+    image_dtype* mask,
     uint8_t* footprint,
     Py_ssize_t footprint_rows,
     Py_ssize_t footprint_cols,
@@ -269,7 +253,7 @@ cdef void perform_reverse_raster_scan(
     image_dtype* image,
     Py_ssize_t image_rows,
     Py_ssize_t image_cols,
-    mask_dtype* mask,
+    image_dtype* mask,
     uint8_t* footprint,
     uint8_t* propagation_footprint,
     Py_ssize_t footprint_rows,
@@ -330,7 +314,7 @@ cdef process_queue(
     image_dtype* image,
     Py_ssize_t image_rows,
     Py_ssize_t image_cols,
-    mask_dtype* mask,
+    image_dtype* mask,
     uint8_t* footprint,
     Py_ssize_t footprint_rows,
     Py_ssize_t footprint_cols,
@@ -351,7 +335,7 @@ cdef process_queue(
         image (image_type[][]): the image to scan
         image_rows (Py_ssize_t): the number of rows in the image
         image_cols (Py_ssize_t): the number of columns in the image
-        mask (mask_dtype*): the image mask (ceiling on image values)
+        mask (image_dtype*): the image mask (ceiling on image values)
         footprint (uint8_t*): the neighborhood footprint
         footprint_rows (Py_ssize_t): the number of rows in the footprint
         footprint_cols (Py_ssize_t): the number of columns in the footprint
@@ -416,7 +400,7 @@ cdef process_queue(
 @cython.wraparound(False)
 def fast_hybrid_reconstruct(
     image_dtype[:, ::1] image,
-        mask_dtype[:, ::1] mask,
+        image_dtype[:, ::1] mask,
         uint8_t[:, ::1] footprint,
         uint8_t method,
         # FIXME(171): offset should be a Py_ssize_t

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -12,7 +12,7 @@ from libc.stdint cimport uint8_t, int8_t, uint16_t, int16_t, uint32_t, int32_t, 
 # Adding more should be a simple matter of adding them to this list.
 
 # Production mode types
-ctypedef fused marker_dtype:
+ctypedef fused image_dtype:
     int8_t
     uint8_t
     int16_t
@@ -36,7 +36,7 @@ ctypedef fused mask_dtype:
     double
 
 # Dev mode types
-# ctypedef fused marker_dtype:
+# ctypedef fused image_dtype:
 #     uint8_t
 #     int16_t
 #     int64_t
@@ -53,15 +53,15 @@ cpdef enum:
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef marker_dtype get_neighborhood_peak(
-    marker_dtype* image,
+cdef image_dtype get_neighborhood_peak(
+    image_dtype* image,
     Py_ssize_t image_rows,
     Py_ssize_t image_cols,
     Py_ssize_t point_row,
     Py_ssize_t point_col,
     uint8_t[:, ::1] footprint,
     uint8_t[::1] offset,
-    marker_dtype border_value,
+    image_dtype border_value,
     uint8_t method,
 ):
     """Get the neighborhood peak around a point.
@@ -76,7 +76,7 @@ cdef marker_dtype get_neighborhood_peak(
     this is the minimum image value.
 
     Args:
-      image (marker_dtype*): the image to scan
+      image (image_dtype*): the image to scan
       image_rows (Py_ssize_t): the number of rows in the image
       image_cols (Py_ssize_t): the number of columns in the image
       point_row (Py_ssize_t): the row of the point to scan
@@ -89,9 +89,9 @@ cdef marker_dtype get_neighborhood_peak(
     Returns:
         my_type: the maximum in the point's neighborhood, greater than or equal to border_value.
     """
-    cdef marker_dtype pixel_value
+    cdef image_dtype pixel_value
     # OOB values get the border value
-    cdef marker_dtype neighborhood_peak = border_value
+    cdef image_dtype neighborhood_peak = border_value
     cdef Py_ssize_t neighbor_row, neighbor_col
     cdef Py_ssize_t footprint_x, footprint_y
     cdef Py_ssize_t offset_row, offset_col
@@ -130,11 +130,11 @@ cdef marker_dtype get_neighborhood_peak(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef uint8_t should_propagate(
-    marker_dtype[:, ::1] image,
+    image_dtype[:, ::1] image,
     mask_dtype[:, ::1] mask,
     Py_ssize_t point_row,
     Py_ssize_t point_col,
-    marker_dtype point_value,
+    image_dtype point_value,
     uint8_t[:, ::1] footprint,
     uint8_t[::1] offset,
     uint8_t method,
@@ -150,11 +150,11 @@ cdef uint8_t should_propagate(
     algorithm, the footprint is the raster footprint without the center point.
 
     Args:
-        image (marker_dtype[][]): the image to scan
+        image (image_dtype[][]): the image to scan
         mask (mask_dtype[][]): the mask to scan
         point_row (Py_ssize_t): the row of the point to scan
         point_col (Py_ssize_t): the column of the point to scan
-        point_value (marker_dtype): the value of the point to scan
+        point_value (image_dtype): the value of the point to scan
         footprint (uint8_t[][]): the neighborhood footprint
         offset (uint8_t[]): the offset of the footprint center.
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
@@ -164,7 +164,7 @@ cdef uint8_t should_propagate(
     """
     cdef Py_ssize_t footprint_row_offset, footprint_col_offset
     cdef Py_ssize_t neighbor_row, neighbor_col
-    cdef marker_dtype neighbor_value
+    cdef image_dtype neighbor_value
     cdef Py_ssize_t image_rows = image.shape[0]
     cdef Py_ssize_t image_cols = image.shape[1]
     cdef Py_ssize_t footprint_center_row = offset[0]
@@ -198,12 +198,12 @@ cdef uint8_t should_propagate(
             neighbor_value = image[neighbor_row, neighbor_col]
             if method == METHOD_DILATION and (
                 neighbor_value < point_value
-                and neighbor_value < <marker_dtype> mask[neighbor_row, neighbor_col]
+                and neighbor_value < <image_dtype> mask[neighbor_row, neighbor_col]
             ):
                 return 1
             elif method == METHOD_EROSION and (
                 neighbor_value > point_value
-                and neighbor_value > <marker_dtype> mask[neighbor_row, neighbor_col]
+                and neighbor_value > <image_dtype> mask[neighbor_row, neighbor_col]
             ):
                 return 1
 
@@ -213,13 +213,13 @@ cdef uint8_t should_propagate(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def fast_hybrid_raster_scans(
-    marker_dtype[:, ::1] marker,
+    image_dtype[:, ::1] image,
     mask_dtype[:, ::1] mask,
     uint8_t[:, ::1] footprint_raster_before,
     uint8_t[:, ::1] footprint_raster_after,
     uint8_t[:, ::1] footprint_propagation_test,
     uint8_t[::1] offset,
-    marker_dtype border_value,
+    image_dtype border_value,
     queue,
     uint8_t method,
 ):
@@ -233,10 +233,10 @@ def fast_hybrid_raster_scans(
     After being scanned in both orders, each point is tested for further
     propagation. If so, the point is added to the provided queue.
 
-    Note that this modifies the marker image in place.
+    Note that this modifies the image in place.
 
     Args:
-        marker (my_type[][]): the image to scan
+        image (my_type[][]): the image to scan
         mask (my_type[][]): the mask to scan
         footprint_raster_before (uint8_t[][]): the raster footprint before the center point
         footprint_raster_after (uint8_t[][]): the raster footprint after the center point
@@ -247,26 +247,26 @@ def fast_hybrid_raster_scans(
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
     """
     cdef Py_ssize_t row, col
-    cdef Py_ssize_t marker_rows, marker_cols
-    cdef marker_dtype neighborhood_peak, point_value, point_mask
+    cdef Py_ssize_t image_rows, image_cols
+    cdef image_dtype neighborhood_peak, point_value, point_mask
 
-    marker_rows = marker.shape[0]
-    marker_cols = marker.shape[1]
+    image_rows = image.shape[0]
+    image_cols = image.shape[1]
 
     # Scan in raster order.
     t = timeit.default_timer()
-    for row in range(marker_rows):
-        for col in range(marker_cols):
-            point_mask = <marker_dtype> mask[row, col]
+    for row in range(image_rows):
+        for col in range(image_cols):
+            point_mask = <image_dtype> mask[row, col]
 
-            # If the marker is already at the limiting mask value, skip this pixel.
-            if marker[row, col] == point_mask:
+            # If the image is already at the limiting mask value, skip this pixel.
+            if image[row, col] == point_mask:
                 continue
 
             neighborhood_peak = get_neighborhood_peak(
-                &marker[0, 0],
-                marker.shape[0],
-                marker.shape[1],
+                &image[0, 0],
+                image.shape[0],
+                image.shape[1],
                 row,
                 col,
                 footprint_raster_before,
@@ -276,25 +276,25 @@ def fast_hybrid_raster_scans(
             )
 
             if method == METHOD_DILATION:
-                marker[row, col] = min(neighborhood_peak, point_mask)
+                image[row, col] = min(neighborhood_peak, point_mask)
             elif method == METHOD_EROSION:
-                marker[row, col] = max(neighborhood_peak, point_mask)
+                image[row, col] = max(neighborhood_peak, point_mask)
 
     logging.debug("Raster scan time: %s", timeit.default_timer() - t)
 
     # Scan in reverse-raster order.
     t = timeit.default_timer()
-    for row in range(marker_rows - 1, -1, -1):
-        for col in range(marker_cols - 1, -1, -1):
-            point_mask = <marker_dtype> mask[row, col]
+    for row in range(image_rows - 1, -1, -1):
+        for col in range(image_cols - 1, -1, -1):
+            point_mask = <image_dtype> mask[row, col]
 
             # If we're already at the mask, skip the neighbor test.
             # But note: we still need to test for propagation (below).
-            if marker[row, col] != point_mask:
+            if image[row, col] != point_mask:
                 neighborhood_peak = get_neighborhood_peak(
-                    &marker[0,0],
-                    marker.shape[0],
-                    marker.shape[1],
+                    &image[0,0],
+                    image.shape[0],
+                    image.shape[1],
                     row,
                     col,
                     footprint_raster_after,
@@ -303,16 +303,16 @@ def fast_hybrid_raster_scans(
                     method,
                 )
                 if method == METHOD_DILATION:
-                    marker[row, col] = min(neighborhood_peak, point_mask)
+                    image[row, col] = min(neighborhood_peak, point_mask)
                 elif method == METHOD_EROSION:
-                    marker[row, col] = max(neighborhood_peak, point_mask)
+                    image[row, col] = max(neighborhood_peak, point_mask)
 
             if should_propagate(
-                    marker,
+                    image,
                     mask,
                     row,
                     col,
-                    marker[row, col],
+                    image[row, col],
                     footprint_propagation_test,
                     offset,
                     method,
@@ -325,37 +325,37 @@ def fast_hybrid_raster_scans(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def process_queue(
-   marker_dtype[:, ::1] marker,
+   image_dtype[:, ::1] image,
    mask_dtype[:, ::1] mask,
    uint8_t[:, ::1] footprint,
    uint8_t[::1] offset,
    queue,
    uint8_t method,
 ):
-    """Process the queue of pixels to propagate through a marker image.
+    """Process the queue of pixels to propagate through a image.
 
     This implements the queue phase of the fast-hybrid reconstruction
     algorithm. During the raster scan phases, we identify pixels that
     may need to propagate through the image. This phase processes
     those queues, propagating the points further as necessary.
 
-    Note that this modifies the marker image in place.
+    Note that this modifies the image in place.
 
     Args:
-        marker (mytype[][]): the marker image to scan
+        image (image_type[][]): the image to scan
         mask (mytype[][]): the image mask (ceiling on image values)
         footprint (uint8_t[][]): the neighborhood footprint
         offset (uint8_t[]): the offset of the footprint center.
         queue (deque): the queue of points to process
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
     """
-    cdef Py_ssize_t marker_rows = marker.shape[0]
-    cdef Py_ssize_t marker_cols = marker.shape[1]
+    cdef Py_ssize_t image_rows = image.shape[0]
+    cdef Py_ssize_t image_cols = image.shape[1]
     cdef Py_ssize_t row, col
     cdef Py_ssize_t footprint_row, footprint_col
     cdef Py_ssize_t neighbor_row, neighbor_col
-    cdef marker_dtype neighbor_mask
-    cdef marker_dtype neighbor_value, point_value
+    cdef image_dtype neighbor_mask
+    cdef image_dtype neighbor_value, point_value
     cdef Py_ssize_t footprint_center_row = offset[0]
     cdef Py_ssize_t footprint_center_col = offset[1]
 
@@ -366,7 +366,7 @@ def process_queue(
         point = queue.popleft()
         row = point[0]
         col = point[1]
-        point_value = marker[row, col]
+        point_value = image[row, col]
 
         # Place the current point at each position of the footprint.
         # If that footprint position is true, then, the current point
@@ -385,21 +385,21 @@ def process_queue(
 
                 if (
                         neighbor_row < 0
-                        or neighbor_row >= marker_rows
+                        or neighbor_row >= image_rows
                         or neighbor_col < 0
-                        or neighbor_col >= marker_cols
+                        or neighbor_col >= image_cols
                 ):
                     # Skip out of bounds
                     continue
 
-                neighbor_value = marker[neighbor_row, neighbor_col]
-                neighbor_mask = <marker_dtype> mask[neighbor_row, neighbor_col]
+                neighbor_value = image[neighbor_row, neighbor_col]
+                neighbor_mask = <image_dtype> mask[neighbor_row, neighbor_col]
 
                 if method == METHOD_DILATION and (point_value > neighbor_value != neighbor_mask):
-                    marker[neighbor_row, neighbor_col] = min(point_value, neighbor_mask)
+                    image[neighbor_row, neighbor_col] = min(point_value, neighbor_mask)
                     queue.append((neighbor_row, neighbor_col))
                 elif method == METHOD_EROSION and (point_value < neighbor_value != neighbor_mask):
-                    marker[neighbor_row, neighbor_col] = max(point_value, neighbor_mask)
+                    image[neighbor_row, neighbor_col] = max(point_value, neighbor_mask)
                     queue.append((neighbor_row, neighbor_col))
 
     logging.debug("Queue processing time: %s", timeit.default_timer() - t)
@@ -407,7 +407,7 @@ def process_queue(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def fast_hybrid_reconstruct(
-    marker_dtype[:, ::1] marker,
+    image_dtype[:, ::1] image,
         mask_dtype[:, ::1] mask,
         uint8_t[:, ::1] footprint,
         uint8_t method,
@@ -434,17 +434,17 @@ def fast_hybrid_reconstruct(
     avoids two sorts and accompanying memory allocations for several-
     hundred-megabyte image files.
 
-    Note that this modifies the marker image in place.
+    Note that this modifies the image in place.
 
     Args:
-        marker (my_type[][]): the marker image
+        image (my_type[][]): the image
         mask (my_type[][]): the mask image
         footprint (uint8_t[][]): the neighborhood footprint aka N(G)
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
         offset (uint8_t[]): the offset of the footprint center.
 
     Returns:
-        my_type[][]: the reconstructed marker image, modified in place
+        my_type[][]: the reconstructed image, modified in place
     """
     cdef Py_ssize_t row, col
     cdef Py_ssize_t footprint_rows, footprint_cols
@@ -452,8 +452,8 @@ def fast_hybrid_reconstruct(
     cdef Py_ssize_t footprint_row_offset, footprint_col_offset
     cdef Py_ssize_t neighbor_row
     cdef Py_ssize_t neighbor_col
-    cdef marker_dtype border_value
-    cdef marker_dtype neighborhood_peak
+    cdef image_dtype border_value
+    cdef image_dtype neighborhood_peak
 
     footprint_rows = footprint.shape[0]
     footprint_center_row = offset[0]
@@ -495,9 +495,9 @@ def fast_hybrid_reconstruct(
 
     # .item() converts the numpy scalar to a python scalar
     if method == METHOD_DILATION:
-        border_value = np.min(marker).item()
+        border_value = np.min(image).item()
     elif method == METHOD_EROSION:
-        border_value = np.max(marker).item()
+        border_value = np.max(image).item()
 
     # The propagation queue for after the raster scans.
     queue = deque()
@@ -505,7 +505,7 @@ def fast_hybrid_reconstruct(
     # Apply the maximum filter in raster order, then in reverse-raster order.
     # The center pixel is included in both of these tests.
     fast_hybrid_raster_scans(
-        marker,
+        image,
         mask,
         footprint_raster_before,
         footprint_raster_after,
@@ -518,7 +518,7 @@ def fast_hybrid_reconstruct(
 
     # Propagate points as necessary.
     process_queue(
-        marker,
+        image,
         mask,
         footprint,
         offset,
@@ -526,5 +526,5 @@ def fast_hybrid_reconstruct(
         method,
     )
 
-    # All done. Return marker (which was modified in place).
-    return marker
+    # All done. Return image (which was modified in place).
+    return image

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -241,16 +241,16 @@ def test_offset_not_none_1d():
 
 def test_offset_not_none():
     """Test reconstruction with valid offset parameter"""
-    seed = np.array([[0, 3, 6, 2, 1, 1, 1, 4, 2, 0]])
-    mask = np.array([[0, 8, 6, 8, 8, 8, 8, 4, 4, 0]])
-    expected = np.array([[0, 6, 6, 4, 4, 4, 4, 4, 2, 0]])
+    seed = np.array([[0, 3, 6, 2, 1, 1, 1, 4, 2, 0]], dtype=np.int16)
+    mask = np.array([[0, 8, 6, 8, 8, 8, 8, 4, 4, 0]], dtype=np.int16)
+    expected = np.array([[0, 6, 6, 4, 4, 4, 4, 4, 2, 0]], dtype=np.int16)
 
     assert_array_almost_equal(
         reconstruction(
             seed,
             mask,
             method="dilation",
-            footprint=np.array([[1, 1, 1]]),
+            footprint=np.array([[1, 1, 1]], np.uint8),
             offset=np.array([0, 0]),
         ),
         expected,


### PR DESCRIPTION
Memory views are nice, but they hardcode the dimensions. That won't work for n-dimensional arrays…

This prepares #118 by refactoring the memory views into pointers. (We'll update the wrapper soon)

Along the way, aligns the mask dtype with the image dtype to dramatically reduce code size. (It's O(N) instead of O(N*N) combinations of types)

Fixes #175 