### PR TITLE
Generalize fast-hybrid to n-dimensional arrays

### DIFF
--- a/benchmarking/h_maxima/.gitignore
+++ b/benchmarking/h_maxima/.gitignore
@@ -1,1 +1,2 @@
 fasthybridreconstruct.c
+fasthybridreconstruct.html

--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -33,6 +33,8 @@ def cython_reconstruct_wrapper(
     if footprint is None:
         footprint = np.ones([3] * image.ndim, dtype=np.uint8)
     else:
+        if footprint.ndim != image.ndim:
+            raise ValueError("Footprint must have same ndim as image")
         footprint = footprint.astype(np.uint8, copy=True)
 
     # The existing skimage code is inconsistent in how it creates the offset.

--- a/benchmarking/h_maxima/fast_reconstruct_wrapper.py
+++ b/benchmarking/h_maxima/fast_reconstruct_wrapper.py
@@ -67,7 +67,7 @@ def cython_reconstruct_wrapper(
         if mask.dtype != normalized_type:
             mask = mask.astype(normalized_type, copy=True)
 
-    offset = offset.astype(np.uint8, copy=True)
+    offset = offset.astype(np.int64, copy=True)
 
     fast_hybrid_reconstruct(
         image=image,

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -540,25 +540,20 @@ cdef process_queue(
                     if not footprint[footprint_linear_coord]:
                         out_of_footprint = True
 
+                # Skip out of bounds
                 # The center point is always skipped.
                 # Also skip if not in footprint.
-                if at_center or out_of_footprint:
-                    continue
+                if not (oob or at_center or out_of_footprint):
+                    neighbor_linear_coord = point_to_linear(neighbor_coord_ptr, image_dimensions, num_dimensions)
+                    neighbor_value = image[neighbor_linear_coord]
+                    neighbor_mask = <image_dtype> mask[neighbor_linear_coord]
 
-                if oob:
-                    # Skip out of bounds
-                    continue
-
-                neighbor_linear_coord = point_to_linear(neighbor_coord_ptr, image_dimensions, num_dimensions)
-                neighbor_value = image[neighbor_linear_coord]
-                neighbor_mask = <image_dtype> mask[neighbor_linear_coord]
-
-                if method == METHOD_DILATION and (point_value > neighbor_value != neighbor_mask):
-                    image[neighbor_linear_coord] = min(point_value, neighbor_mask)
-                    queue.append(neighbor_linear_coord)
-                elif method == METHOD_EROSION and (point_value < neighbor_value != neighbor_mask):
-                    image[neighbor_linear_coord] = max(point_value, neighbor_mask)
-                    queue.append(neighbor_linear_coord)
+                    if method == METHOD_DILATION and (point_value > neighbor_value != neighbor_mask):
+                        image[neighbor_linear_coord] = min(point_value, neighbor_mask)
+                        queue.append(neighbor_linear_coord)
+                    elif method == METHOD_EROSION and (point_value < neighbor_value != neighbor_mask):
+                        image[neighbor_linear_coord] = max(point_value, neighbor_mask)
+                        queue.append(neighbor_linear_coord)
 
     logging.debug("Queue processing time: %s", timeit.default_timer() - t)
 

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -171,8 +171,6 @@ cdef image_dtype get_neighborhood_peak(
 
     cdef Py_ssize_t image_rows = image_dimensions[0]
     cdef Py_ssize_t image_cols = image_dimensions[1]
-    cdef Py_ssize_t footprint_center_row = offset[0]
-    cdef Py_ssize_t footprint_center_col = offset[1]
 
     cdef Py_ssize_t footprint_rows = footprint_dimensions[0]
     cdef Py_ssize_t footprint_cols = footprint_dimensions[1]
@@ -186,6 +184,7 @@ cdef image_dtype get_neighborhood_peak(
     cdef Py_ssize_t cur_dimension
     cdef uint8_t end = 0
     cdef uint8_t oob
+    cdef uint8_t at_center
 
     while True:
         # do the thing on this index…
@@ -201,10 +200,16 @@ cdef image_dtype get_neighborhood_peak(
                 oob = True
                 break
 
+        at_center = True
+        for dim in range(num_dimensions):
+            if indices_ptr[dim] != offset[dim]:
+                at_center = False
+                break
+
         linear_coord = point_to_linear(indices_ptr, footprint_dimensions, num_dimensions)
         if ((
                 not footprint[linear_coord]
-                and not (indices_ptr[0] == footprint_center_row and indices_ptr[1] == footprint_center_col)
+                and not at_center
         ) or (
                 oob
         )):

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -35,6 +35,8 @@ cpdef enum:
     METHOD_DILATION = 0
     METHOD_EROSION = 1
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 cdef Py_ssize_t point_to_linear(
     Py_ssize_t* point,
     Py_ssize_t* dimensions,
@@ -65,6 +67,8 @@ def point_to_linear_python(point, dimensions, num_dimensions):
     cdef Py_ssize_t num_dims = <Py_ssize_t> num_dimensions
     return <long> point_to_linear(point_ptr, dimensions_ptr, num_dims)
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 cdef Py_ssize_t* linear_to_point(
     Py_ssize_t linear,
     Py_ssize_t* point_output,

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -220,8 +220,7 @@ cdef uint8_t should_propagate(
     Py_ssize_t* image_dimensions,
     Py_ssize_t num_dimensions,
     image_dtype* mask,
-    Py_ssize_t point_row,
-    Py_ssize_t point_col,
+    Py_ssize_t* point_coord,
     image_dtype point_value,
     uint8_t* footprint,
     Py_ssize_t* footprint_dimensions,
@@ -243,8 +242,7 @@ cdef uint8_t should_propagate(
         image_dimensions (Py_ssize_t*): the size of each dimension
         num_dimensions (Py_ssize_t): the number of image dimensions
         mask (image_dtype*): the mask to apply
-        point_row (Py_ssize_t): the row of the point to scan
-        point_col (Py_ssize_t): the column of the point to scan
+        point_coord (Py_ssize_t*): the coordinates of the point to scan
         point_value (image_dtype): the value of the point to scan
         footprint (uint8_t*): the neighborhood footprint
         footprint_dimensions (Py_ssize_t*): the size of each dimension of the footprint
@@ -264,6 +262,9 @@ cdef uint8_t should_propagate(
     cdef Py_ssize_t image_cols = image_dimensions[1]
     cdef Py_ssize_t footprint_rows = footprint_dimensions[0]
     cdef Py_ssize_t footprint_cols = footprint_dimensions[1]
+
+    cdef point_row = point_coord[0]
+    cdef point_col = point_coord[1]
 
     # Place the current point at each position of the footprint.
     # If that footprint position is true, then, the current point
@@ -426,8 +427,7 @@ cdef void perform_reverse_raster_scan(
                     image_dimensions,
                     num_dimensions,
                     mask,
-                    row,
-                    col,
+                    coord_ptr,
                     image[row * image_cols + col],
                     propagation_footprint,
                     footprint_dimensions,

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -561,8 +561,7 @@ def fast_hybrid_reconstruct(
     mask,
     footprint,
     uint8_t method,
-    # FIXME(171): offset should be a Py_ssize_t
-    uint8_t[::1] offset
+    offset
 ):
     return fast_hybrid_reconstruct_impl(
         image.dtype.type(0),
@@ -573,14 +572,15 @@ def fast_hybrid_reconstruct(
         offset,
     )
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 def fast_hybrid_reconstruct_impl(
     image_dtype dummy_value,
     image,
     mask,
     footprint,
     uint8_t method,
-    # FIXME(171): offset should be a Py_ssize_t
-    uint8_t[::1] offset
+    offset
 ):
     """Perform grayscale reconstruction using the 'Fast-Hybrid' algorithm.
 
@@ -606,20 +606,19 @@ def fast_hybrid_reconstruct_impl(
     Note that this modifies the image in place.
 
     Args:
-        image (image_dtype[][]): the image
-        mask (image_dtype[][]): the mask image
-        footprint (uint8_t[][]): the neighborhood footprint aka N(G)
+        image (numpy array of type: image_dtype): the image
+        mask (numpy array of type: image_dtype): the mask image
+        footprint (numpy array of type: uint8_t): the neighborhood footprint aka N(G)
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
-        offset (uint8_t[]): the offset of the footprint center.
+        offset (numpy array of type: Py_ssize_t): the offset of the footprint center.
 
     Returns:
-        image_dtype[][]: the reconstructed image, modified in place
+        numpy array of type image_dtype: the reconstructed image, modified in place
     """
     cdef image_dtype border_value
     cdef Py_ssize_t num_dimensions = image.ndim
 
-    offset_numpy = np.array(offset, dtype=np.int64, copy=True)
-    cdef Py_ssize_t* offset_ptr = <Py_ssize_t*> <Py_ssize_t> offset_numpy.ctypes.data
+    cdef Py_ssize_t* offset_ptr = <Py_ssize_t*> <Py_ssize_t> offset.ctypes.data
     footprint_dimensions = np.array(footprint.shape, dtype=np.int64)
     cdef Py_ssize_t* footprint_dimensions_ptr = <Py_ssize_t*> <Py_ssize_t> footprint_dimensions.ctypes.data
 

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -154,16 +154,16 @@ cdef image_dtype get_neighborhood_peak(
     cdef Py_ssize_t footprint_rows = footprint_dimensions[0]
     cdef Py_ssize_t footprint_cols = footprint_dimensions[1]
 
-    for offset_row in range(-footprint_center_row, footprint_rows - footprint_center_row):
-        for offset_col in range(-footprint_center_col, footprint_cols - footprint_center_col):
+    for offset_row in range(footprint_rows):
+        for offset_col in range(footprint_cols):
             # Skip this point if not in the footprint, and not the center point.
             # (The center point is always included in the neighborhood.)
-            if (not footprint[(footprint_center_row + offset_row) * footprint_cols + footprint_center_col + offset_col]
-                    and not (offset_row == 0 and offset_col == 0)):
+            if (not footprint[offset_row * footprint_cols + offset_col]
+                    and not (offset_row == footprint_center_row and offset_col == footprint_center_col)):
                 continue
 
-            neighbor_row = point_row + offset_row
-            neighbor_col = point_col + offset_col
+            neighbor_row = point_row + offset_row - footprint_center_row
+            neighbor_col = point_col + offset_col - footprint_center_col
 
             if (
                 neighbor_row < 0

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -167,7 +167,6 @@ cdef image_dtype get_neighborhood_peak(
     # OOB values get the border value
     cdef image_dtype neighborhood_peak = border_value
     cdef Py_ssize_t neighbor_row, neighbor_col
-    cdef Py_ssize_t offset_row, offset_col
     cdef Py_ssize_t linear_coord
 
     cdef Py_ssize_t image_rows = image_dimensions[0]
@@ -190,8 +189,8 @@ cdef image_dtype get_neighborhood_peak(
 
     while True:
         # do the thing on this index…
-        offset_row = indices[0]
-        offset_col = indices[1]
+
+        # Calculate the neighbor's coordinates
         for dim in range(num_dimensions):
             neighbor_ptr[dim] = point_coord[dim] + indices_ptr[dim] - offset[dim]
 
@@ -202,9 +201,10 @@ cdef image_dtype get_neighborhood_peak(
                 oob = True
                 break
 
+        linear_coord = point_to_linear(indices_ptr, footprint_dimensions, num_dimensions)
         if ((
-                not footprint[offset_row * footprint_cols + offset_col]
-                and not (offset_row == footprint_center_row and offset_col == footprint_center_col)
+                not footprint[linear_coord]
+                and not (indices_ptr[0] == footprint_center_row and indices_ptr[1] == footprint_center_col)
         ) or (
                 oob
         )):

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -2,7 +2,6 @@
 
 from collections import deque
 import logging
-import math
 import numpy as np
 import timeit
 
@@ -626,9 +625,7 @@ def fast_hybrid_reconstruct_impl(
     cdef Py_ssize_t linear_center = point_to_linear(offset_ptr, footprint_dimensions_ptr, num_dimensions)
 
     cdef Py_ssize_t num_before = linear_center
-    # For some reason the shape comes back as an array with several zeros.
-    # Just select the actual dimensions out of it.
-    cdef Py_ssize_t num_after = math.prod(footprint.shape) - linear_center - 1
+    cdef Py_ssize_t num_after = np.prod(footprint.shape) - linear_center - 1
 
     # N+(G), the pixels *before* & including the center in a raster scan.
     ones_before = np.concatenate(
@@ -668,7 +665,6 @@ def fast_hybrid_reconstruct_impl(
     # The propagation queue for after the raster scans.
     queue = deque()
 
-    # TODO: do these need to be py_ssize_t or should they be uint8_t ?
     cdef uint8_t* footprint_ptr = <uint8_t*> <Py_ssize_t> footprint.ctypes.data
     cdef uint8_t* footprint_before_ptr = <uint8_t*> <Py_ssize_t> footprint_raster_before.ctypes.data
     cdef uint8_t* footprint_after_ptr = <uint8_t*> <Py_ssize_t> footprint_raster_after.ctypes.data

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -44,8 +44,7 @@ cdef image_dtype get_neighborhood_peak(
     Py_ssize_t point_row,
     Py_ssize_t point_col,
     uint8_t* footprint,
-    Py_ssize_t footprint_rows,
-    Py_ssize_t footprint_cols,
+    Py_ssize_t* footprint_dimensions,
     uint8_t* offset,
     image_dtype border_value,
     uint8_t method,
@@ -68,8 +67,7 @@ cdef image_dtype get_neighborhood_peak(
       point_row (Py_ssize_t): the row of the point to scan
       point_col (Py_ssize_t): the column of the point to scan
       footprint (uint8_t*): the neighborhood footprint
-      footprint_rows (Py_ssize_t): the number of rows in the footprint
-      footprint_cols (Py_ssize_t): the number of columns in the footprint
+      footprint_dimensions (Py_ssize_t*): the size of each dimension of the footprint
       offset (uint8_t*): the offset of the footprint center.
       border_value (image_dtype): the value to use for out-of-bound points
       method (uint8_t): METHOD_DILATION or METHOD_EROSION
@@ -88,6 +86,9 @@ cdef image_dtype get_neighborhood_peak(
     cdef Py_ssize_t image_cols = image_dimensions[1]
     cdef Py_ssize_t footprint_center_row = offset[0]
     cdef Py_ssize_t footprint_center_col = offset[1]
+
+    cdef Py_ssize_t footprint_rows = footprint_dimensions[0]
+    cdef Py_ssize_t footprint_cols = footprint_dimensions[1]
 
     for offset_row in range(-footprint_center_row, footprint_rows - footprint_center_row):
         for offset_col in range(-footprint_center_col, footprint_cols - footprint_center_col):
@@ -128,8 +129,7 @@ cdef uint8_t should_propagate(
     Py_ssize_t point_col,
     image_dtype point_value,
     uint8_t* footprint,
-    Py_ssize_t footprint_rows,
-    Py_ssize_t footprint_cols,
+    Py_ssize_t* footprint_dimensions,
     uint8_t* offset,
     uint8_t method,
 ):
@@ -152,8 +152,7 @@ cdef uint8_t should_propagate(
         point_col (Py_ssize_t): the column of the point to scan
         point_value (image_dtype): the value of the point to scan
         footprint (uint8_t*): the neighborhood footprint
-        footprint_rows (Py_ssize_t): the number of rows in the footprint
-        footprint_cols (Py_ssize_t): the number of columns in the footprint
+        footprint_dimensions (Py_ssize_t*): the size of each dimension of the footprint
         offset (uint8_t*): the offset of the footprint center.
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
 
@@ -168,6 +167,8 @@ cdef uint8_t should_propagate(
     cdef Py_ssize_t footprint_row, footprint_col
     cdef Py_ssize_t image_rows = image_dimensions[0]
     cdef Py_ssize_t image_cols = image_dimensions[1]
+    cdef Py_ssize_t footprint_rows = footprint_dimensions[0]
+    cdef Py_ssize_t footprint_cols = footprint_dimensions[1]
 
     # Place the current point at each position of the footprint.
     # If that footprint position is true, then, the current point
@@ -216,8 +217,7 @@ cdef void perform_raster_scan(
     Py_ssize_t num_dimensions,
     image_dtype* mask,
     uint8_t* footprint,
-    Py_ssize_t footprint_rows,
-    Py_ssize_t footprint_cols,
+    Py_ssize_t* footprint_dimensions,
     uint8_t* offset,
     image_dtype border_value,
     uint8_t method,
@@ -243,8 +243,7 @@ cdef void perform_raster_scan(
                 row,
                 col,
                 footprint,
-                footprint_rows,
-                footprint_cols,
+                footprint_dimensions,
                 offset,
                 border_value,
                 method,
@@ -265,8 +264,7 @@ cdef void perform_reverse_raster_scan(
     image_dtype* mask,
     uint8_t* footprint,
     uint8_t* propagation_footprint,
-    Py_ssize_t footprint_rows,
-    Py_ssize_t footprint_cols,
+    Py_ssize_t* footprint_dimensions,
     uint8_t* offset,
     image_dtype border_value,
     uint8_t method,
@@ -292,8 +290,7 @@ cdef void perform_reverse_raster_scan(
                     row,
                     col,
                     footprint,
-                    footprint_rows,
-                    footprint_cols,
+                    footprint_dimensions,
                     offset,
                     border_value,
                     method,
@@ -312,8 +309,7 @@ cdef void perform_reverse_raster_scan(
                     col,
                     image[row * image_cols + col],
                     propagation_footprint,
-                    footprint_rows,
-                    footprint_cols,
+                    footprint_dimensions,
                     offset,
                     method,
             ):
@@ -328,8 +324,7 @@ cdef process_queue(
     Py_ssize_t num_dimensions,
     image_dtype* mask,
     uint8_t* footprint,
-    Py_ssize_t footprint_rows,
-    Py_ssize_t footprint_cols,
+    Py_ssize_t* footprint_dimensions,
     uint8_t* offset,
     queue,
     uint8_t method,
@@ -349,8 +344,7 @@ cdef process_queue(
         num_dimensions (Py_ssize_t): the number of image dimensions
         mask (image_dtype*): the image mask (ceiling on image values)
         footprint (uint8_t*): the neighborhood footprint
-        footprint_rows (Py_ssize_t): the number of rows in the footprint
-        footprint_cols (Py_ssize_t): the number of columns in the footprint
+        footprint_dimensions (Py_ssize_t*): the size of each dimension of the footprint
         offset (uint8_t*): the offset of the footprint center.
         queue (deque): the queue of points to process
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
@@ -364,6 +358,8 @@ cdef process_queue(
     cdef Py_ssize_t footprint_center_col = offset[1]
     cdef Py_ssize_t image_rows = image_dimensions[0]
     cdef Py_ssize_t image_cols = image_dimensions[1]
+    cdef Py_ssize_t footprint_rows = footprint_dimensions[0]
+    cdef Py_ssize_t footprint_cols = footprint_dimensions[1]
 
     # Process the queue of pixels that need to be updated.
     logging.debug("Queue size: %s", len(queue))
@@ -521,6 +517,8 @@ def fast_hybrid_reconstruct(
     cdef Py_ssize_t* image_dimensions_ptr = <Py_ssize_t*> <Py_ssize_t> image_dimensions.ctypes.data
     cdef Py_ssize_t num_dimensions = image.ndim
 
+    cdef Py_ssize_t* footprint_dimensions_ptr = <Py_ssize_t*> <Py_ssize_t> footprint.shape
+
     t = timeit.default_timer()
     perform_raster_scan(
         &image[0, 0],
@@ -528,8 +526,7 @@ def fast_hybrid_reconstruct(
         num_dimensions,
         &mask[0, 0],
         footprint_before_ptr,
-        footprint_rows,
-        footprint_cols,
+        footprint_dimensions_ptr,
         offset_ptr,
         border_value,
         method,
@@ -544,8 +541,7 @@ def fast_hybrid_reconstruct(
         &mask[0, 0],
         footprint_after_ptr,
         footprint_propagation_ptr,
-        footprint_rows,
-        footprint_cols,
+        footprint_dimensions_ptr,
         offset_ptr,
         border_value,
         method,
@@ -560,8 +556,7 @@ def fast_hybrid_reconstruct(
         num_dimensions,
         &mask[0, 0],
         &footprint[0, 0],
-        footprint_rows,
-        footprint_cols,
+        footprint_dimensions_ptr,
         offset_ptr,
         queue,
         method,

--- a/benchmarking/h_maxima/test_fast_hybrid.py
+++ b/benchmarking/h_maxima/test_fast_hybrid.py
@@ -1,0 +1,19 @@
+import math
+import numpy as np
+import pytest
+from numpy.testing import assert_array_almost_equal
+from fasthybridreconstruct import point_to_linear_python, linear_to_point_python
+
+
+def test_point_to_linear():
+    point = np.array([1, 2, 3])
+    shape = np.array([4, 5, 6])
+    linear = point_to_linear_python(point, shape, len(shape))
+    assert linear == 3 + 2 * 6 + 1 * 6 * 5
+
+
+def test_linear_to_point():
+    linear = 3 + 2 * 6 + 1 * 6 * 5
+    shape = np.array([4, 5, 6])
+    point = linear_to_point_python(linear, shape, len(shape))
+    assert_array_almost_equal(point, [1, 2, 3])

--- a/benchmarking/h_maxima/test_reconstruction.py
+++ b/benchmarking/h_maxima/test_reconstruction.py
@@ -139,7 +139,6 @@ def test_fill_hole(dtype):
     assert_array_almost_equal(result, expected)
 
 
-@xfail(reason="n dimensions, https://github.com/dchaley/deepcell-imaging/issues/118")
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -224,12 +223,11 @@ def test_invalid_offset_not_none():
         )
 
 
-@xfail(reason="n dimensions, https://github.com/dchaley/deepcell-imaging/issues/118")
 def test_offset_not_none_1d():
     """Test reconstruction with valid offset parameter"""
     seed = np.array([0, 3, 6, 2, 1, 1, 1, 4, 2, 0])
     mask = np.array([0, 8, 6, 8, 8, 8, 8, 4, 4, 0])
-    expected = np.array([0, 3, 6, 6, 6, 6, 6, 4, 4, 0])
+    expected = np.array([0, 6, 6, 4, 4, 4, 4, 4, 2, 0])
 
     assert_array_almost_equal(
         reconstruction(


### PR DESCRIPTION
Refactors the fast-hybrid algorithm to support n-dimensional arrays.

See PR commits for step-by-step refactors from memory views & row/col indexing, into general C pointer indexing.

Fixes #118 
Fixes #171 

Commits from Mar 22, 2024 paired with Weihao