### PR TITLE
Reduce number of inner loops & cythonize time

### DIFF
--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -42,7 +42,7 @@ cdef inline uint8_t increment_index(
     Py_ssize_t* indices_ptr,
     Py_ssize_t* dimensions_ptr,
     Py_ssize_t num_dimensions,
-):
+) nogil:
     """Increment an index in N dimensions.
 
     Args:
@@ -69,7 +69,7 @@ cdef inline Py_ssize_t point_to_linear(
     Py_ssize_t* coord_ptr,
     Py_ssize_t* dimensions_ptr,
     Py_ssize_t num_dimensions,
-):
+) nogil:
     """Convert a point in N dimensions to a linear index.
 
     Args:
@@ -102,7 +102,7 @@ cdef inline Py_ssize_t* linear_to_point(
     Py_ssize_t* point_output_ptr,
     Py_ssize_t* dimensions_ptr,
     Py_ssize_t num_dimensions,
-):
+) nogil:
     """Convert a linear index to a point in N dimensions.
 
     Args:
@@ -142,7 +142,7 @@ cdef image_dtype get_neighborhood_peak(
     uint8_t method,
     Py_ssize_t* footprint_coord_ptr,
     Py_ssize_t* neighbor_coord_ptr,
-):
+) nogil:
     """Get the neighborhood peak around a point.
 
     For dilation, this is the maximum in the neighborhood. For erosion, the minimum.
@@ -238,7 +238,7 @@ cdef uint8_t should_propagate(
     uint8_t method,
     Py_ssize_t* footprint_coord_ptr,
     Py_ssize_t* neighbor_coord_ptr,
-):
+) nogil:
     """Determine if a point should be propagated to its neighbors.
 
     This implements the queue test during the raster scan/anti-scan.

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -29,6 +29,7 @@ ctypedef fused image_dtype:
 #     uint8_t
 #     int16_t
 #     int64_t
+#     float
 #     double
 
 cpdef enum:

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -38,7 +38,7 @@ cpdef enum:
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef uint8_t increment_index(
+cdef inline uint8_t increment_index(
     Py_ssize_t* indices_ptr,
     Py_ssize_t* dimensions_ptr,
     Py_ssize_t num_dimensions,
@@ -65,7 +65,7 @@ cdef uint8_t increment_index(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef Py_ssize_t point_to_linear(
+cdef inline Py_ssize_t point_to_linear(
     Py_ssize_t* coord_ptr,
     Py_ssize_t* dimensions_ptr,
     Py_ssize_t num_dimensions,
@@ -97,7 +97,7 @@ def point_to_linear_python(point, dimensions, num_dimensions):
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef Py_ssize_t* linear_to_point(
+cdef inline Py_ssize_t* linear_to_point(
     Py_ssize_t linear,
     Py_ssize_t* point_output_ptr,
     Py_ssize_t* dimensions_ptr,

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -689,7 +689,7 @@ cdef void fast_hybrid_reconstruct_impl(
     cdef Py_ssize_t footprint_linear_center = point_to_linear(offset_ptr, footprint_dimensions_ptr, num_dimensions)
 
     cdef Py_ssize_t num_before = footprint_linear_center
-    cdef Py_ssize_t num_after = np.prod(footprint.shape) - footprint_linear_center - 1
+    cdef Py_ssize_t num_after = np.prod(footprint.shape) - footprint_linear_center - <Py_ssize_t> 1
 
     # N+(G), the pixels *before* & including the center in a raster scan.
     ones_before = np.concatenate(

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -24,14 +24,6 @@ ctypedef fused image_dtype:
     float
     double
 
-# Dev mode types
-# ctypedef fused image_dtype:
-#     uint8_t
-#     int16_t
-#     int64_t
-#     float
-#     double
-
 cpdef enum:
     METHOD_DILATION = 0
     METHOD_EROSION = 1

--- a/benchmarking/h_maxima/fasthybridreconstruct.pyx
+++ b/benchmarking/h_maxima/fasthybridreconstruct.pyx
@@ -31,15 +31,15 @@ cpdef enum:
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef inline uint8_t increment_index(
-    Py_ssize_t* indices_ptr,
-    Py_ssize_t* dimensions_ptr,
+    Py_ssize_t* indices,
+    Py_ssize_t* dimensions,
     Py_ssize_t num_dimensions,
 ) nogil:
     """Increment an index in N dimensions.
 
     Args:
-        indices_ptr (Py_ssize_t*): the indices to increment
-        dimensions_ptr (Py_ssize_t*): the size of each dimension
+        indices (Py_ssize_t*): the indices to increment
+        dimensions (Py_ssize_t*): the size of each dimension
         num_dimensions (Py_ssize_t): the number of dimensions
 
     Returns:
@@ -47,11 +47,11 @@ cdef inline uint8_t increment_index(
     """
     cdef Py_ssize_t i
     for i in range(num_dimensions - 1, -1, -1):
-        if indices_ptr[i] < dimensions_ptr[i] - 1:
-            indices_ptr[i] += 1
+        if indices[i] < dimensions[i] - 1:
+            indices[i] += 1
             return 0
         else:
-            indices_ptr[i] = 0
+            indices[i] = 0
             if i == 0:
                 return 1
 
@@ -59,15 +59,15 @@ cdef inline uint8_t increment_index(
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef inline uint8_t decrement_index(
-        Py_ssize_t* indices_ptr,
-        Py_ssize_t* dimensions_ptr,
+        Py_ssize_t* indices,
+        Py_ssize_t* dimensions,
         Py_ssize_t num_dimensions,
 ) nogil:
     """Decrement an index in N dimensions.
 
     Args:
-        indices_ptr (Py_ssize_t*): the indices to increment
-        dimensions_ptr (Py_ssize_t*): the size of each dimension
+        indices (Py_ssize_t*): the indices to increment
+        dimensions (Py_ssize_t*): the size of each dimension
         num_dimensions (Py_ssize_t): the number of dimensions
 
     Returns:
@@ -75,37 +75,37 @@ cdef inline uint8_t decrement_index(
     """
     cdef Py_ssize_t i
     for i in range(num_dimensions - 1, -1, -1):
-        if indices_ptr[i] > 0:
-            indices_ptr[i] -= 1
+        if indices[i] > 0:
+            indices[i] -= 1
             return 0
         else:
-            indices_ptr[i] = dimensions_ptr[i] - 1
+            indices[i] = dimensions[i] - 1
             if i == 0:
                 return 1
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline Py_ssize_t point_to_linear(
-    Py_ssize_t* coord_ptr,
-    Py_ssize_t* dimensions_ptr,
+cdef inline Py_ssize_t coord_to_index(
+    Py_ssize_t* coord,
+    Py_ssize_t* dimensions,
     Py_ssize_t num_dimensions,
 ) nogil:
-    """Convert a point in N dimensions to a linear index.
+    """Convert an N-dimensional coordinate to a linear index.
 
     Args:
-        coord_ptr (Py_ssize_t*): the point to convert
-        dimensions_ptr (Py_ssize_t*): the size of each dimension
+        coord (Py_ssize_t*): the coordinate to convert
+        dimensions (Py_ssize_t*): the size of each dimension
         num_dimensions (Py_ssize_t): the number of dimensions
 
     Returns:
-        Py_ssize_t: the linear index
+        Py_ssize_t: the coordinates as an index
     """
     cdef Py_ssize_t linear = 0
     cdef Py_ssize_t multiplier = 1
     cdef Py_ssize_t i
     for i in range(num_dimensions - 1, -1, -1):
-        linear += coord_ptr[i] * multiplier
-        multiplier *= dimensions_ptr[i]
+        linear += coord[i] * multiplier
+        multiplier *= dimensions[i]
     return linear
 
 # for testing; test_fast_hybrid.py
@@ -113,31 +113,28 @@ def point_to_linear_python(point, dimensions, num_dimensions):
     cdef Py_ssize_t* point_ptr = <Py_ssize_t*> <Py_ssize_t> point.ctypes.data
     cdef Py_ssize_t* dimensions_ptr = <Py_ssize_t*> <Py_ssize_t> dimensions.ctypes.data
     cdef Py_ssize_t num_dims = <Py_ssize_t> num_dimensions
-    return <long> point_to_linear(point_ptr, dimensions_ptr, num_dims)
+    return <long> coord_to_index(point_ptr, dimensions_ptr, num_dims)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef inline Py_ssize_t* linear_to_point(
-    Py_ssize_t linear,
-    Py_ssize_t* point_output_ptr,
-    Py_ssize_t* dimensions_ptr,
+cdef inline void index_to_coord(
+    Py_ssize_t index,
+    Py_ssize_t* coord_output,
+    Py_ssize_t* dimensions,
     Py_ssize_t num_dimensions,
 ) nogil:
-    """Convert a linear index to a point in N dimensions.
+    """Convert an index to coordinates in N dimensions.
 
     Args:
-        linear (Py_ssize_t): the linear index
-        point_output_ptr (Py_ssize_t*): the point to write to
-        dimensions_ptr (Py_ssize_t*): the size of each dimension
+        index (Py_ssize_t): the index
+        coord_output (Py_ssize_t*): the coordinate buffer to write to
+        dimensions (Py_ssize_t*): the size of each dimension
         num_dimensions (Py_ssize_t): the number of dimensions
-
-    Returns:
-        Py_ssize_t*: the point
     """
     cdef Py_ssize_t i
     for i in range(num_dimensions - 1, -1, -1):
-        point_output_ptr[i] = cython.cmod(linear, dimensions_ptr[i])
-        linear = cython.cdiv(linear, dimensions_ptr[i])
+        coord_output[i] = cython.cmod(index, dimensions[i])
+        index = cython.cdiv(index, dimensions[i])
 
 # for testing; test_fast_hybrid.py
 def linear_to_point_python(linear, dimensions, num_dimensions):
@@ -145,7 +142,7 @@ def linear_to_point_python(linear, dimensions, num_dimensions):
     cdef Py_ssize_t* point_output_ptr = <Py_ssize_t*> <Py_ssize_t> point.ctypes.data
     cdef Py_ssize_t* dimensions_ptr = <Py_ssize_t*> <Py_ssize_t> dimensions.ctypes.data
     cdef Py_ssize_t num_dims = <Py_ssize_t> num_dimensions
-    linear_to_point(linear, point_output_ptr, dimensions_ptr, num_dims)
+    index_to_coord(linear, point_output_ptr, dimensions_ptr, num_dims)
     return point
 
 @cython.boundscheck(False)
@@ -158,22 +155,22 @@ cdef inline uint8_t offset_coord(
     Py_ssize_t sign,
     Py_ssize_t* dimensions,
     Py_ssize_t num_dimensions,
-    Py_ssize_t* result_linear_index,
+    Py_ssize_t* result_index,
     uint8_t* at_center,
 ) nogil:
-    """Offset (add) the starting point by the offset point minus a center point.
+    """Offset (add) the starting coord by the offset coordinate minus a center offset.
 
-    If the sign is negative, the offset-center is subtracted instead.
+    If the sign is negative, the offset center is subtracted.
 
     If any dimension is out of bounds, return false and skip assigning more coordinates.
 
-    Otherwise, set all dimension coordinates, the linear index, and whether the point is at the center.
+    Otherwise, set all dimension coordinates, the linear index, and whether the coordinate is at the center.
 
     Returns:
         uint8_t: 1 if the neighbor is in bounds, 0 otherwise.
     """
     cdef Py_ssize_t i
-    result_linear_index[0] = 0
+    result_index[0] = 0
     cdef Py_ssize_t multiplier = 1
     at_center[0] = True
     for i in range(num_dimensions - 1, -1, -1):
@@ -183,33 +180,33 @@ cdef inline uint8_t offset_coord(
         if result_coord[i] < 0 or result_coord[i] >= dimensions[i]:
             return 0
 
-        result_linear_index[0] += result_coord[i] * multiplier
+        result_index[0] += result_coord[i] * multiplier
         multiplier *= dimensions[i]
 
         if at_center[0] and offset_coord[i] != footprint_center_offset[i]:
             at_center[0] = False
 
-    # Each dimension is in bounds.
+    # True: each dimension is in bounds.
     return 1
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef image_dtype get_neighborhood_peak(
-    image_dtype* image_ptr,
-    Py_ssize_t* image_dimensions_ptr,
+cdef inline image_dtype get_neighborhood_peak(
+    image_dtype* image,
+    Py_ssize_t* image_dimensions,
     Py_ssize_t num_dimensions,
-    Py_ssize_t* center_coord_ptr,
+    Py_ssize_t* center_coord,
     uint8_t* footprint_ptr,
     Py_ssize_t footprint_start_index,
     Py_ssize_t footprint_end_index,
-    Py_ssize_t* footprint_dimensions_ptr,
-    Py_ssize_t* footprint_center_ptr,
+    Py_ssize_t* footprint_dimensions,
+    Py_ssize_t* footprint_center_coord,
     image_dtype border_value,
     uint8_t method,
-    Py_ssize_t* footprint_coord_ptr,
-    Py_ssize_t* neighbor_coord_ptr,
+    Py_ssize_t* footprint_scan_coord,
+    Py_ssize_t* neighbor_coord,
 ) nogil:
-    """Get the neighborhood peak around a point.
+    """Get the neighborhood peak around a coordinate.
 
     For dilation, this is the maximum in the neighborhood. For erosion, the minimum.
 
@@ -217,21 +214,22 @@ cdef image_dtype get_neighborhood_peak(
     the footprint is 0, and included otherwise. The footprint must have
     an odd number of rows and columns, and is anchored at the center.
 
-    border_value is used for out-of-bounds points. In expected usage,
-    this is the minimum image value.
+    border_value is used for out-of-bound points.
 
     Args:
-      image_ptr (image_dtype*): the image to scan
-      image_dimensions_ptr (Py_ssize_t*): the size of each dimension
+      image (image_dtype*): the image to scan
+      image_dimensions (Py_ssize_t*): the size of each dimension
       num_dimensions (Py_ssize_t): the number of image dimensions
-      center_coord_ptr (Py_ssize_t*): the coordinates of the point to scan
+      center_coord (Py_ssize_t*): the coordinates of the neighborhood center point
       footprint_ptr (uint8_t*): the neighborhood footprint
-      footprint_dimensions_ptr (Py_ssize_t*): the size of each dimension of the footprint
-      footprint_center_ptr (uint8_t*): the offset of the footprint center.
+      footprint_start_index (Py_ssize_t): the start index of the footprint scan (inclusive)
+      footprint_end_index (Py_ssize_t): the end index of the footprint scan (inclusive)
+      footprint_dimensions (Py_ssize_t*): the size of each dimension of the footprint
+      footprint_center_coord (uint8_t*): the offset of the footprint center.
       border_value (image_dtype): the value to use for out-of-bound points
       method (uint8_t): METHOD_DILATION or METHOD_EROSION
-      footprint_coord_ptr (Py_ssize_t*): a scratch space for indices
-      neighbor_coord_ptr (Py_ssize_t*): a scratch space for neighbor coordinates
+      footprint_scan_coord (Py_ssize_t*): a scratch space for indices
+      neighbor_coord (Py_ssize_t*): a scratch space for neighbor coordinates
 
     Returns:
         image_dtype: the maximum in the point's neighborhood, greater than or equal to border_value.
@@ -239,38 +237,39 @@ cdef image_dtype get_neighborhood_peak(
     cdef image_dtype pixel_value
     # The peak starts at the border value, and is updated up (or down) as necessary.
     cdef image_dtype neighborhood_peak = border_value
-    cdef Py_ssize_t neighbor_linear_index = 0
+    cdef Py_ssize_t neighbor_index = 0
 
     cdef uint8_t oob
     cdef uint8_t at_center
 
     # Set the neighborhood loop coordinate to the start.
-    cdef Py_ssize_t linear_index = footprint_start_index
-    linear_to_point(footprint_start_index, footprint_coord_ptr, footprint_dimensions_ptr, num_dimensions)
+    cdef Py_ssize_t footprint_scan_index = footprint_start_index
+    index_to_coord(footprint_start_index, footprint_scan_coord, footprint_dimensions, num_dimensions)
 
     while True:
         oob = not offset_coord(
-            center_coord_ptr,
-            footprint_center_ptr,
-            footprint_coord_ptr,
-            neighbor_coord_ptr,
-            1,
-            image_dimensions_ptr,
+            center_coord,
+            footprint_center_coord,
+            footprint_scan_coord,
+            neighbor_coord,
+            1, # we are testing if the point is our neighbor
+            image_dimensions,
             num_dimensions,
-            &neighbor_linear_index,
+            &neighbor_index,
             &at_center,
         )
 
-        # Consider in-bound points in the footprint or at the current point.
-        if not oob and (at_center or footprint_ptr[linear_index]):
-            pixel_value = image_ptr[neighbor_linear_index]
+        # Exclude out-of-bound points.
+        # Consider neighbors in the footprint, or, the center.
+        if not oob and (at_center or footprint_ptr[footprint_scan_index]):
+            pixel_value = image[neighbor_index]
             if method == METHOD_DILATION:
                 neighborhood_peak = max(neighborhood_peak, pixel_value)
             elif method == METHOD_EROSION:
                 neighborhood_peak = min(neighborhood_peak, pixel_value)
 
-        linear_index += 1
-        if linear_index > footprint_end_index or increment_index(footprint_coord_ptr, footprint_dimensions_ptr, num_dimensions):
+        footprint_scan_index += 1
+        if footprint_scan_index > footprint_end_index or increment_index(footprint_scan_coord, footprint_dimensions, num_dimensions):
             break
 
     return neighborhood_peak
@@ -278,19 +277,19 @@ cdef image_dtype get_neighborhood_peak(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef uint8_t should_propagate(
-    image_dtype* image_ptr,
-    Py_ssize_t* image_dimensions_ptr,
+cdef inline uint8_t should_propagate(
+    image_dtype* image,
+    Py_ssize_t* image_dimensions,
     Py_ssize_t num_dimensions,
-    image_dtype* mask_ptr,
-    Py_ssize_t* coord_ptr,
-    image_dtype point_value,
-    uint8_t* footprint_ptr,
-    Py_ssize_t* footprint_dimensions_ptr,
-    Py_ssize_t* footprint_center_ptr,
+    image_dtype* mask,
+    Py_ssize_t* scan_coord,
+    image_dtype scan_value,
+    uint8_t* footprint,
+    Py_ssize_t* footprint_dimensions,
+    Py_ssize_t* footprint_center_coord,
     uint8_t method,
-    Py_ssize_t* footprint_coord_ptr,
-    Py_ssize_t* neighbor_coord_ptr,
+    Py_ssize_t* footprint_coord,
+    Py_ssize_t* neighbor_coord,
 ) nogil:
     """Determine if a point should be propagated to its neighbors.
 
@@ -299,38 +298,33 @@ cdef uint8_t should_propagate(
     through the image.
 
     The image and mask must be of the same type and shape. The footprint
-    is anchored at the offset point. In the fast-hybrid-reconstruct
-    algorithm, the footprint is the raster footprint without the center point.
+    is anchored at the center coord.
 
     Args:
-        image_ptr (image_dtype*): the image to scan
-        image_dimensions_ptr (Py_ssize_t*): the size of each dimension
+        image (image_dtype*): the image to scan
+        image_dimensions (Py_ssize_t*): the size of each dimension
         num_dimensions (Py_ssize_t): the number of image dimensions
-        mask_ptr (image_dtype*): the mask to apply
-        coord_ptr (Py_ssize_t*): the coordinates of the point to scan
-        point_value (image_dtype): the value of the point to scan
-        footprint_ptr (uint8_t*): the neighborhood footprint
-        footprint_dimensions_ptr (Py_ssize_t*): the size of each dimension of the footprint
-        footprint_center_ptr (uint8_t*): the offset of the footprint center.
+        mask (image_dtype*): the mask to apply
+        scan_coord (Py_ssize_t*): the coordinates to potentially propagate
+        scan_value (image_dtype): the value to potentially propagate
+        footprint (uint8_t*): the neighborhood footprint
+        footprint_dimensions (Py_ssize_t*): the size of each dimension of the footprint
+        footprint_center_coord (uint8_t*): the offset of the footprint center.
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
-        footprint_coord_ptr (Py_ssize_t*): a scratch space for indices
-        neighbor_coord_ptr (Py_ssize_t*): a scratch space for neighbor coordinates
+        footprint_coord (Py_ssize_t*): a scratch space for indices
+        neighbor_coord (Py_ssize_t*): a scratch space for neighbor coordinates
 
     Returns:
         uint8_t: 1 if the point should be propagated, 0 otherwise.
     """
     cdef image_dtype neighbor_value
 
-    cdef Py_ssize_t footprint_linear_index = 0
-    cdef Py_ssize_t neighbor_linear_index = 0
-    cdef Py_ssize_t dimension
-    cdef uint8_t oob
-    cdef uint8_t at_center
-    cdef Py_ssize_t center_linear_index = point_to_linear(footprint_center_ptr, footprint_dimensions_ptr, num_dimensions)
+    cdef Py_ssize_t footprint_center_index = coord_to_index(footprint_center_coord, footprint_dimensions, num_dimensions)
+    cdef Py_ssize_t footprint_index = 0
+    index_to_coord(footprint_index, footprint_coord, footprint_dimensions, num_dimensions)
 
-    # Reset the loop points to zero.
-    for dimension in range(num_dimensions):
-        footprint_coord_ptr[dimension] = 0
+    cdef Py_ssize_t neighbor_index
+    cdef uint8_t oob, at_center
 
     # For each point the queue point could propagate to, in
     # other words for each point this point is a neighbor of,
@@ -338,14 +332,14 @@ cdef uint8_t should_propagate(
     # for further propagation.
     while True:
         oob = not offset_coord(
-            coord_ptr,
-            footprint_center_ptr,
-            footprint_coord_ptr,
-            neighbor_coord_ptr,
+            scan_coord,
+            footprint_center_coord,
+            footprint_coord,
+            neighbor_coord,
             -1, # we are testing for points of which *this point* is a neighbor
-            image_dimensions_ptr,
+            image_dimensions,
             num_dimensions,
-            &neighbor_linear_index,
+            &neighbor_index,
             &at_center,
         )
 
@@ -353,266 +347,28 @@ cdef uint8_t should_propagate(
         # - out-of-bounds points
         # - the center point
         # - points not in the footprint
-        if not oob and not at_center and footprint_ptr[footprint_linear_index]:
-            neighbor_value = image_ptr[neighbor_linear_index]
+        if not oob and not at_center and footprint[footprint_index]:
+            neighbor_value = image[neighbor_index]
             if method == METHOD_DILATION and (
-                neighbor_value < point_value
-                and neighbor_value < mask_ptr[neighbor_linear_index]
+                    neighbor_value < scan_value
+                    and neighbor_value < mask[neighbor_index]
             ):
                 return 1
             elif method == METHOD_EROSION and (
-                    neighbor_value > point_value
-                    and neighbor_value > mask_ptr[neighbor_linear_index]
+                    neighbor_value > scan_value
+                    and neighbor_value > mask[neighbor_index]
             ):
                 return 1
 
-        footprint_linear_index += 1
+        footprint_index += 1
         # Stop the loop if we've reached the center point.
         # Otherwise, increment and continue.
-        if footprint_linear_index > center_linear_index:
+        if footprint_index > footprint_center_index:
             break
         else:
-            increment_index(footprint_coord_ptr, footprint_dimensions_ptr, num_dimensions)
+            increment_index(footprint_coord, footprint_dimensions, num_dimensions)
 
     return 0
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cdef void perform_raster_scan(
-    image_dtype* image_ptr,
-    Py_ssize_t* image_dimensions_ptr,
-    Py_ssize_t num_dimensions,
-    image_dtype* mask_ptr,
-    uint8_t* footprint_ptr,
-    Py_ssize_t* footprint_dimensions_ptr,
-    Py_ssize_t* footprint_center_ptr,
-    image_dtype border_value,
-    uint8_t method,
-):
-    cdef image_dtype neighborhood_peak, point_mask
-    cdef Py_ssize_t scan_linear_index = 0
-    cdef Py_ssize_t center_linear_index = point_to_linear(footprint_center_ptr, footprint_dimensions_ptr, num_dimensions)
-
-    scan_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
-    cdef Py_ssize_t* scan_coord_ptr = <Py_ssize_t*> <Py_ssize_t> scan_coord_numpy.ctypes.data
-
-    # We use these 2 buffers to avoid re-allocating them in the inner loop.
-    loop_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
-    neighbor_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
-    cdef Py_ssize_t* loop_coord_ptr = <Py_ssize_t*> <Py_ssize_t> loop_coord_numpy.ctypes.data
-    cdef Py_ssize_t* neighbor_coord_ptr = <Py_ssize_t*> <Py_ssize_t> neighbor_coord_numpy.ctypes.data
-
-    while True:
-        point_mask = <image_dtype> mask_ptr[scan_linear_index]
-
-        # Skip if the image is already at the limiting mask value.
-        if image_ptr[scan_linear_index] != point_mask:
-            neighborhood_peak = get_neighborhood_peak(
-                image_ptr,
-                image_dimensions_ptr,
-                num_dimensions,
-                scan_coord_ptr,
-                footprint_ptr,
-                0,
-                center_linear_index,
-                footprint_dimensions_ptr,
-                footprint_center_ptr,
-                border_value,
-                method,
-                loop_coord_ptr,
-                neighbor_coord_ptr,
-            )
-
-            if method == METHOD_DILATION:
-                image_ptr[scan_linear_index] = min(neighborhood_peak, point_mask)
-            elif method == METHOD_EROSION:
-                image_ptr[scan_linear_index] = max(neighborhood_peak, point_mask)
-
-        scan_linear_index += 1
-        if increment_index(scan_coord_ptr, image_dimensions_ptr, num_dimensions):
-            break
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cdef void perform_reverse_raster_scan(
-    image_dtype* image_ptr,
-    Py_ssize_t* image_dimensions_ptr,
-    Py_ssize_t num_dimensions,
-    image_dtype* mask_ptr,
-    uint8_t* footprint_ptr,
-    Py_ssize_t* footprint_dimensions_ptr,
-    Py_ssize_t* footprint_center_ptr,
-    image_dtype border_value,
-    uint8_t method,
-    queue,
-):
-    cdef image_dtype neighborhood_peak, point_mask
-    cdef Py_ssize_t center_linear_index = point_to_linear(footprint_center_ptr, footprint_dimensions_ptr, num_dimensions)
-    cdef Py_ssize_t footprint_end_linear_index = 0
-    cdef Py_ssize_t multiplier = 1
-
-    cdef Py_ssize_t scan_linear_index
-    scan_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
-    cdef Py_ssize_t* scan_coord_ptr = <Py_ssize_t*> <Py_ssize_t> scan_coord_numpy.ctypes.data
-
-    # Initialize the scan coordinate to the end of the image.
-    # Also initialize the footprint end linear index.
-    cdef Py_ssize_t dimension
-    for dimension in range(num_dimensions - 1, -1, -1):
-        scan_coord_ptr[dimension] = image_dimensions_ptr[dimension] - 1
-        footprint_end_linear_index += (footprint_dimensions_ptr[dimension] - 1) * multiplier
-        multiplier *= footprint_dimensions_ptr[dimension]
-
-    scan_linear_index = point_to_linear(scan_coord_ptr, image_dimensions_ptr, num_dimensions)
-
-    # We use these 2 buffers to avoid re-allocating them in the inner loop.
-    loop_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
-    neighbor_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
-    cdef Py_ssize_t* loop_coord_ptr = <Py_ssize_t*> <Py_ssize_t> loop_coord_numpy.ctypes.data
-    cdef Py_ssize_t* neighbor_coord_ptr = <Py_ssize_t*> <Py_ssize_t> neighbor_coord_numpy.ctypes.data
-
-    while True:
-        point_mask = <image_dtype> mask_ptr[scan_linear_index]
-
-        # If we're already at the mask, skip the neighbor test.
-        # But note: we still need to test for propagation (below).
-        if image_ptr[scan_linear_index] != point_mask:
-            neighborhood_peak = get_neighborhood_peak(
-                image_ptr,
-                image_dimensions_ptr,
-                num_dimensions,
-                scan_coord_ptr,
-                footprint_ptr,
-                center_linear_index,
-                footprint_end_linear_index,
-                footprint_dimensions_ptr,
-                footprint_center_ptr,
-                border_value,
-                method,
-                loop_coord_ptr,
-                neighbor_coord_ptr,
-            )
-            if method == METHOD_DILATION:
-                image_ptr[scan_linear_index] = min(neighborhood_peak, point_mask)
-            elif method == METHOD_EROSION:
-                image_ptr[scan_linear_index] = max(neighborhood_peak, point_mask)
-
-        if should_propagate(
-                image_ptr,
-                image_dimensions_ptr,
-                num_dimensions,
-                mask_ptr,
-                scan_coord_ptr,
-                image_ptr[scan_linear_index],
-                footprint_ptr,
-                footprint_dimensions_ptr,
-                footprint_center_ptr,
-                method,
-                loop_coord_ptr,
-                neighbor_coord_ptr,
-        ):
-            queue.append(scan_linear_index)
-
-        scan_linear_index -= 1
-        if decrement_index(scan_coord_ptr, image_dimensions_ptr, num_dimensions):
-            break
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cdef process_queue(
-    image_dtype* image_ptr,
-    Py_ssize_t* image_dimensions_ptr,
-    Py_ssize_t num_dimensions,
-    image_dtype* mask_ptr,
-    uint8_t* footprint_ptr,
-    Py_ssize_t* footprint_dimensions_ptr,
-    Py_ssize_t* offset_ptr,
-    queue,
-    uint8_t method,
-):
-    """Process the queue of pixels to propagate through a image.
-
-    This implements the queue phase of the fast-hybrid reconstruction
-    algorithm. During the raster scan phases, we identify pixels that
-    may need to propagate through the image. This phase processes
-    those queues, propagating the points further as necessary.
-
-    Note that this modifies the image in place.
-
-    Args:
-        image_ptr (image_type[][]): the image to scan
-        image_dimensions_ptr (Py_ssize_t*): the size of each dimension
-        num_dimensions (Py_ssize_t): the number of image dimensions
-        mask_ptr (image_dtype*): the image mask (ceiling on image values)
-        footprint_ptr (uint8_t*): the neighborhood footprint
-        footprint_dimensions_ptr (Py_ssize_t*): the size of each dimension of the footprint
-        offset_ptr (uint8_t*): the offset of the footprint center.
-        queue (deque): the queue of points to process
-        method (uint8_t): METHOD_DILATION or METHOD_EROSION
-    """
-    cdef Py_ssize_t queue_pt_linear_index
-    cdef image_dtype neighbor_mask
-    cdef image_dtype neighbor_value, point_value
-
-    coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
-    cdef Py_ssize_t* queue_pt_coord_ptr = <Py_ssize_t*> <Py_ssize_t> coord_numpy.ctypes.data
-
-    # Pre-allocate these 2 buffers & re-use them in loops later.
-    loop_coord_numpy = np.array([0] * num_dimensions, dtype=np.int64)
-    neighbor_coord_numpy = np.array([0] * num_dimensions, dtype=np.int64)
-    cdef Py_ssize_t* loop_coord_ptr = <Py_ssize_t*> <Py_ssize_t> loop_coord_numpy.ctypes.data
-    cdef Py_ssize_t* neighbor_coord_ptr = <Py_ssize_t*> <Py_ssize_t> neighbor_coord_numpy.ctypes.data
-
-    cdef Py_ssize_t neighbor_linear_index
-    cdef Py_ssize_t footprint_linear_index = 0
-
-    cdef uint8_t oob
-    cdef uint8_t at_center
-
-    # Process the queue of pixels that need to be updated.
-    while len(queue) > 0:
-        queue_pt_linear_index = queue.popleft()
-        linear_to_point(queue_pt_linear_index, queue_pt_coord_ptr, image_dimensions_ptr, num_dimensions)
-        point_value = image_ptr[queue_pt_linear_index]
-        footprint_linear_index = 0
-
-        # For each point the queue point could propagate to, in
-        # other words for each point this point is a neighbor of,
-        # propagate if necessary & add that point to the queue
-        # for further propagation.
-        while True:
-            oob = not offset_coord(
-                queue_pt_coord_ptr,
-                offset_ptr,
-                loop_coord_ptr,
-                neighbor_coord_ptr,
-                -1, # we are testing for points of which *this point* is a neighbor
-                image_dimensions_ptr,
-                num_dimensions,
-                &neighbor_linear_index,
-                &at_center,
-            )
-
-            # Skip out of bounds
-            # The center point is always skipped.
-            # Also skip if not in footprint.
-            if not oob and not at_center and footprint_ptr[footprint_linear_index]:
-                neighbor_value = image_ptr[neighbor_linear_index]
-                neighbor_mask = <image_dtype> mask_ptr[neighbor_linear_index]
-
-                if method == METHOD_DILATION and (point_value > neighbor_value != neighbor_mask):
-                    image_ptr[neighbor_linear_index] = min(point_value, neighbor_mask)
-                    queue.append(neighbor_linear_index)
-                elif method == METHOD_EROSION and (point_value < neighbor_value != neighbor_mask):
-                    image_ptr[neighbor_linear_index] = max(point_value, neighbor_mask)
-                    queue.append(neighbor_linear_index)
-
-            footprint_linear_index += 1
-            if increment_index(loop_coord_ptr, footprint_dimensions_ptr, num_dimensions):
-                break
 
 
 @cython.boundscheck(False)
@@ -658,11 +414,11 @@ def fast_hybrid_reconstruct(
 @cython.wraparound(False)
 cdef void fast_hybrid_reconstruct_impl(
     image_dtype _dummy_value,
-    image,
-    mask,
-    footprint,
+    image_numpy,
+    mask_numpy,
+    footprint_numpy,
     uint8_t method,
-    offset
+    footprint_center_numpy
 ):
     """Perform grayscale reconstruction using the 'Fast-Hybrid' algorithm.
 
@@ -689,98 +445,217 @@ cdef void fast_hybrid_reconstruct_impl(
 
     Args:
         _dummy_value (image_dtype): a dummy value of the image dtype for type matching
-        image (numpy array of type: image_dtype): the image
-        mask (numpy array of type: image_dtype): the mask image
-        footprint (numpy array of type: uint8_t): the neighborhood footprint aka N(G)
+        image_numpy (numpy array of type: image_dtype): the image
+        mask_numpy (numpy array of type: image_dtype): the mask image
+        footprint_numpy (numpy array of type: uint8_t): the neighborhood footprint aka N(G)
         method (uint8_t): METHOD_DILATION or METHOD_EROSION
-        offset (numpy array of type: Py_ssize_t): the offset of the footprint center.
+        footprint_center_numpy (numpy array of type: Py_ssize_t): the offset of the footprint center.
 
     Returns:
         numpy array of type image_dtype: the reconstructed image, modified in place
     """
     cdef image_dtype border_value
-    cdef Py_ssize_t num_dimensions = image.ndim
-
-    cdef Py_ssize_t* offset_ptr = <Py_ssize_t*> <Py_ssize_t> offset.ctypes.data
-
-    footprint_dimensions = np.array(footprint.shape, dtype=np.int64)
-    cdef Py_ssize_t* footprint_dimensions_ptr = <Py_ssize_t*> <Py_ssize_t> footprint_dimensions.ctypes.data
-
-    # The center point, in 1d linear order.
-    cdef Py_ssize_t footprint_linear_center = point_to_linear(offset_ptr, footprint_dimensions_ptr, num_dimensions)
-
-    # TODO: this should go somewhere else…
-    # Vincent '93 uses N- as the propagation test.
-    # In other words, it checks all q ∈ N-(p) : the points after.
-    # The idea is, in our anti-raster scan, do we need to propagate
-    # "back" in raster direction. Updating p could affect points
-    # which have p as a neighbor.
-    # For a symmetric footprint, if q ∈ N-(p) then, by symmetry, p ∈ N+(q).
-    # So checking N-(p) is equivalent to checking N+(q).
-    #
-    # However, an asymmetric footprint doesn't have this property.
-    # TODO: I think we only need to check N- because we're scanning back to N+ anyhow
-    footprint_propagation_test = np.copy(footprint)
 
     # .item() converts the numpy scalar to a python scalar
     if method == METHOD_DILATION:
-        border_value = np.min(image).item()
+        border_value = np.min(image_numpy).item()
     elif method == METHOD_EROSION:
-        border_value = np.max(image).item()
+        border_value = np.max(image_numpy).item()
+    else:
+        raise ValueError("Unknown method: %s" % method)
 
     # The propagation queue for after the raster scans.
     queue = deque()
 
-    cdef uint8_t* footprint_ptr = <uint8_t*> <Py_ssize_t> footprint.ctypes.data
+    # Get the C buffers from the numpy parameters.
+    cdef Py_ssize_t* footprint_center_coord = <Py_ssize_t*> <Py_ssize_t> footprint_center_numpy.ctypes.data
+    cdef image_dtype* image = <image_dtype*> <Py_ssize_t> image_numpy.ctypes.data
+    cdef image_dtype* mask = <image_dtype*> <Py_ssize_t> mask_numpy.ctypes.data
+    cdef uint8_t* footprint = <uint8_t*> <Py_ssize_t> footprint_numpy.ctypes.data
 
-    image_dimensions = np.array(image.shape, dtype=np.int64)
-    cdef Py_ssize_t* image_dimensions_ptr = <Py_ssize_t*> <Py_ssize_t> image_dimensions.ctypes.data
-    cdef image_dtype* image_ptr = <image_dtype*> <Py_ssize_t> image.ctypes.data
-    cdef image_dtype* mask_ptr = <image_dtype*> <Py_ssize_t> mask.ctypes.data
+    # Create C buffers to hold the image & footprint dimensions.
+    image_dimensions_numpy = np.array(image_numpy.shape, dtype=np.int64)
+    footprint_dimensions_numpy = np.array(footprint_numpy.shape, dtype=np.int64)
+    cdef Py_ssize_t* image_dimensions = <Py_ssize_t*> <Py_ssize_t> image_dimensions_numpy.ctypes.data
+    cdef Py_ssize_t* footprint_dimensions = <Py_ssize_t*> <Py_ssize_t> footprint_dimensions_numpy.ctypes.data
+
+    cdef Py_ssize_t num_dimensions = image_numpy.ndim
+    cdef Py_ssize_t footprint_center_index = coord_to_index(footprint_center_coord, footprint_dimensions, num_dimensions)
+
+    # Scan variables.
+
+    # Image & mask values for the current scan or neighbor points.
+    cdef image_dtype scan_value, scan_mask, neighbor_value, neighbor_mask
+    # The neighborhood peak value.
+    cdef image_dtype neighborhood_peak
+
+    # The current scan point coordinates.
+    cdef Py_ssize_t scan_index = 0
+    scan_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
+    cdef Py_ssize_t* scan_coord = <Py_ssize_t*> <Py_ssize_t> scan_coord_numpy.ctypes.data
+
+    # The current coordinate in a footprint loop.
+    cdef Py_ssize_t footprint_scan_index = 0
+    footprint_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
+    cdef Py_ssize_t* footprint_coord = <Py_ssize_t*> <Py_ssize_t> footprint_coord_numpy.ctypes.data
+
+    # The coordinates of a neighbor point.
+    neighbor_coord_numpy = np.zeros(num_dimensions, dtype=np.int64)
+    cdef Py_ssize_t* neighbor_coord = <Py_ssize_t*> <Py_ssize_t> neighbor_coord_numpy.ctypes.data
+
+    ###############
+    # Raster scan #
+    ###############
 
     t = timeit.default_timer()
-    perform_raster_scan(
-        image_ptr,
-        image_dimensions_ptr,
-        num_dimensions,
-        mask_ptr,
-        footprint_ptr,
-        footprint_dimensions_ptr,
-        offset_ptr,
-        border_value,
-        method,
-    )
+    while True:
+        scan_mask = <image_dtype> mask[scan_index]
+
+        # Skip if the image is already at the limiting mask value.
+        if image[scan_index] != scan_mask:
+            neighborhood_peak = get_neighborhood_peak(
+                image,
+                image_dimensions,
+                num_dimensions,
+                scan_coord,
+                footprint,
+                0,
+                footprint_center_index,
+                footprint_dimensions,
+                footprint_center_coord,
+                border_value,
+                method,
+                footprint_coord,
+                neighbor_coord,
+            )
+
+            if method == METHOD_DILATION:
+                image[scan_index] = min(neighborhood_peak, scan_mask)
+            elif method == METHOD_EROSION:
+                image[scan_index] = max(neighborhood_peak, scan_mask)
+
+        scan_index += <Py_ssize_t> 1
+        if increment_index(scan_coord, image_dimensions, num_dimensions):
+            break
+
     logging.debug("Raster scan time: %s", timeit.default_timer() - t)
 
+    #######################
+    # Reverse raster scan #
+    #######################
+
+    # Initialize the scan coordinate to the end of the image.
+    # Also initialize the footprint end linear index.
+    cdef Py_ssize_t dimension
+    for dimension in range(num_dimensions - 1, -1, -1):
+        scan_coord[dimension] = image_dimensions[dimension] - <Py_ssize_t> 1
+        footprint_coord[dimension] = footprint_dimensions[dimension] - <Py_ssize_t> 1
+
+    scan_index = coord_to_index(scan_coord, image_dimensions, num_dimensions)
+    footprint_end_index = coord_to_index(footprint_coord, footprint_dimensions, num_dimensions)
+
     t = timeit.default_timer()
-    perform_reverse_raster_scan(
-        image_ptr,
-        image_dimensions_ptr,
-        num_dimensions,
-        mask_ptr,
-        footprint_ptr,
-        footprint_dimensions_ptr,
-        offset_ptr,
-        border_value,
-        method,
-        queue,
-    )
+    while True:
+        scan_mask = mask[scan_index]
+
+        # If we're already at the mask, skip the neighbor test.
+        # But note: we still need to test for propagation (below).
+        if image[scan_index] != scan_mask:
+            neighborhood_peak = get_neighborhood_peak(
+                image,
+                image_dimensions,
+                num_dimensions,
+                scan_coord,
+                footprint,
+                footprint_center_index,
+                footprint_end_index,
+                footprint_dimensions,
+                footprint_center_coord,
+                border_value,
+                method,
+                footprint_coord,
+                neighbor_coord,
+            )
+            if method == METHOD_DILATION:
+                image[scan_index] = min(neighborhood_peak, scan_mask)
+            elif method == METHOD_EROSION:
+                image[scan_index] = max(neighborhood_peak, scan_mask)
+
+        if should_propagate(
+                image,
+                image_dimensions,
+                num_dimensions,
+                mask,
+                scan_coord,
+                image[scan_index],
+                footprint,
+                footprint_dimensions,
+                footprint_center_coord,
+                method,
+                footprint_coord,
+                neighbor_coord,
+        ):
+            queue.append(scan_index)
+
+        scan_index -= <Py_ssize_t> 1
+        if decrement_index(scan_coord, image_dimensions, num_dimensions):
+            break
+
     logging.debug("Reverse raster scan time: %s", timeit.default_timer() - t)
 
-    # Propagate points as necessary.
+    #####################
+    # Queue propagation #
+    #####################
+
+    cdef Py_ssize_t neighbor_index
+    cdef uint8_t oob, at_center
+
     logging.debug("Queue size: %s" % len(queue))
     t = timeit.default_timer()
-    process_queue(
-        image_ptr,
-        image_dimensions_ptr,
-        num_dimensions,
-        mask_ptr,
-        footprint_ptr,
-        footprint_dimensions_ptr,
-        offset_ptr,
-        queue,
-        method,
-    )
+
+    while len(queue) > 0:
+        scan_index = queue.popleft()
+        index_to_coord(scan_index, scan_coord, image_dimensions, num_dimensions)
+        footprint_scan_index = 0
+        index_to_coord(footprint_scan_index, footprint_coord, footprint_dimensions, num_dimensions)
+
+        # For each point the queue point could propagate to, in
+        # other words for each point this point is a neighbor of,
+        # propagate if necessary & add that point to the queue
+        # for further propagation.
+        while True:
+            oob = not offset_coord(
+                scan_coord,
+                footprint_center_coord,
+                footprint_coord,
+                neighbor_coord,
+                -1, # we are testing for points of which *this point* is a neighbor
+                image_dimensions,
+                num_dimensions,
+                &neighbor_index,
+                &at_center,
+            )
+
+            # Skip:
+            # - out-of-bounds points
+            # - the center point
+            # - points not in the footprint
+            if not oob and not at_center and footprint[footprint_scan_index]:
+                scan_value = image[scan_index]
+                neighbor_value = image[neighbor_index]
+                neighbor_mask = mask[neighbor_index]
+
+                if method == METHOD_DILATION and (scan_value > neighbor_value != neighbor_mask):
+                    image[neighbor_index] = min(scan_value, neighbor_mask)
+                    queue.append(neighbor_index)
+                elif method == METHOD_EROSION and (scan_value < neighbor_value != neighbor_mask):
+                    image[neighbor_index] = max(scan_value, neighbor_mask)
+                    queue.append(neighbor_index)
+
+            footprint_scan_index += <Py_ssize_t> 1
+            if increment_index(footprint_coord, footprint_dimensions, num_dimensions):
+                break
+
     logging.debug("Queue processing time: %s", timeit.default_timer() - t)
 
     # All done. Image was modified in place.


### PR DESCRIPTION
Until this PR, we were iterating over the entire footprint, having zero'd out the before or after points as appropriate for the use. That was correct, but wasteful as we don't need to scan points in the inner loop that we're about to scan in the outer loop.

Along the way: I fixed the reverse scan to actually ... 🤦🏻  scan in reverse.

I also renamed & reorganized the code a bunch, aiming for clarity on top of performance. Also, removing some functions reduced the cythonize time (cython to C + compilation) by ~50%. 🎉 

_Highly Scientific Laptop Benchmark Results:_
Total time for OpenCV comparison: 6min 3s
Time to cythonize: ~14s

The cythonize time was previously ~26s, and total time was ... I think ... ~7min. (Should time this later?..., for science 🔬 )