### PR TITLE
Use smaller tf base image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,18 +1,30 @@
-FROM us-docker.pkg.dev/deeplearning-platform-release/gcr.io/tf2-gpu.2-8.py37
+# Base container image is the official tensorflow 2.8.4-gpu image.
+FROM tensorflow/tensorflow:2.8.4-gpu
 
-# The google special container is:
-# us-docker.pkg.dev/vertex-ai-restricted/prediction/tf_opt-gpu.2-8:latest
-#
-# See also:
-# https://cloud.google.com/vertex-ai/docs/predictions/optimized-tensorflow-runtime#available_container_images
+# Refresh the key to nvidia's repositories.
+# https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 
+# Update installed packages & install graphviz & git
+# Clear out the aptitude cache as well.
+# Lastly, install and/or update pip.
+RUN apt-get update && \
+    apt-get install -y graphviz git && \
+    rm -rf /var/lib/apt/lists/* && \
+    /usr/bin/python3 -m pip install --no-cache-dir --upgrade pip
 
+# Add the repo sha to the container as the version.
 ADD https://api.github.com/repos/dchaley/deepcell-imaging/git/refs/heads/main version.json
 
+# Clone the deepcell-imaging repo
 RUN git clone https://github.com/dchaley/deepcell-imaging.git
 
+# Switch into the repo directory
 WORKDIR "/deepcell-imaging"
 
-RUN pip install --user --upgrade --quiet -r requirements.txt
+# Install python requirements
+RUN pip install --user --upgrade -r requirements.txt
 
+# The container entrypoint is the benchmark script.
+# Command-line arguments go to the script.
 ENTRYPOINT ["python", "benchmarking/deepcell-e2e/benchmark.py"]

--- a/container/batch.json
+++ b/container/batch.json
@@ -27,7 +27,7 @@
                 "installGpuDrivers": true,
                 "policy": {
                   "machineType": "n1-standard-8",
-                  "provisioningModel": "STANDARD",
+                  "provisioningModel": "SPOT",
                     "accelerators": [
                         {
                             "type": "nvidia-tesla-t4",


### PR DESCRIPTION
Previous compressed container size: 8.4 GB
New compressed container size: 3.2 GB

Paired with @WeihaoGe1009 

Fixes #192 