### PR TITLE
Add script to submit a batch job

### DIFF
--- a/batch/README.md
+++ b/batch/README.md
@@ -1,0 +1,37 @@
+# Running DeepCell batch jobs
+
+This directory contains tools to submit DeepCell batch jobs.
+
+## Usage
+
+1. Set up an environment.
+
+   1. The easiest is to just open Cloud Shell in the project.
+
+      Go to console.cloud.google.com, select the project, & click the terminal icon. You can upload files to cloud shell under the "More" menu (three dots).
+
+   2. You can also install `gcloud` to your local computer, run `gcloud auth`, etc.
+
+2. Submit the job:
+
+   1. Pick an input file. This should be a .npz file like the ones we have here: `gs://davids-genomics-data-public/cellular-segmentation/10x-genomics/preview-human-breast-20221103-418mb/input_channels.npz`
+
+   2. From the repo base directory, run the script.
+      ```sh
+      batch/run-job.py --input_channels_path="$input_npz_file"
+      ```
+
+   3. The script will output the job ID plus the output directory.
+
+3. Go to the Batch app in GCP console and wait for termination.
+
+   1. There's no feedback yet! See: https://github.com/dchaley/deepcell-imaging/issues/217
+
+## Todo
+
+This helper script has a few drawbacks compared to manually crafting a job json file as described in [the `container` directory](../container)
+
+* Always visualizes input + predictions.
+* Can't customize instance type.
+* Can't customize GPU. (Always uses 1 T4)
+* Can't customize parallelism, vCPUs, etc.

--- a/batch/run-job.py
+++ b/batch/run-job.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import tempfile
+import uuid
+
+parser = argparse.ArgumentParser("deepcell-on-batch")
+parser.add_argument(
+    "--input_channels_path",
+    help="Path to the input channels npz file",
+    type=str,
+    required=True,
+)
+
+args = parser.parse_args()
+
+job_id = "j" + str(uuid.uuid4())
+input_channels_path = args.input_channels_path
+
+CONTAINER_IMAGE = "us-central1-docker.pkg.dev/deepcell-on-batch/deepcell-benchmarking-us-central1/benchmarking:gce"
+OUTPUT_BASE_PATH = "gs://deepcell-batch-jobs_us-central1/job-runs"
+REGION = "us-central1"
+
+output_path = "{}/{}".format(OUTPUT_BASE_PATH, job_id)
+
+# A lot of stuff gets hardcoded in this json.
+# See the README for limitations.
+
+# Need to escape the curly braces in the JSON template
+base_json = """
+{{
+    "taskGroups": [
+        {{
+            "taskSpec": {{
+                "runnables": [
+                    {{
+                        "container": {{
+                            "imageUri": "{container_image}",
+                            "commands": [
+                                "--input_channels_path={input_channels_path}",
+                                "--output_path={output_path}",
+                                "--visualize_input",
+                                "--visualize_predictions",
+                                "--provisioning_model=spot"
+                            ]
+                        }}
+                    }}
+                ],
+                "computeResource": {{
+                    "memoryMib": 26000
+                }},
+                "maxRetryCount": 3,
+                "lifecyclePolicies": [
+                  {{
+                    "action": "RETRY_TASK",
+                    "actionCondition": {{
+                      "exitCodes": [50001]
+                    }}
+                  }}
+                ]
+            }},
+            "taskCount": 1,
+            "parallelism": 1
+        }}
+    ],
+    "allocationPolicy": {{
+        "instances": [
+            {{
+                "installGpuDrivers": true,
+                "policy": {{
+                  "machineType": "n1-standard-8",
+                  "provisioningModel": "SPOT",
+                    "accelerators": [
+                        {{
+                            "type": "nvidia-tesla-t4",
+                            "count": 1
+                        }}
+                    ]
+                }}
+            }}
+        ],
+        "location": {{
+            "allowedLocations": [
+                "regions/{region}"
+            ]
+        }}
+    }},
+    "logsPolicy": {{
+        "destination": "CLOUD_LOGGING"
+    }}
+}}
+"""
+
+job_json_str = base_json.format(
+    output_path=output_path,
+    input_channels_path=input_channels_path,
+    container_image=CONTAINER_IMAGE,
+    region=REGION,
+)
+
+job_json_file = tempfile.NamedTemporaryFile()
+with open(job_json_file.name, "w") as f:
+    f.write(job_json_str)
+
+cmd = "gcloud batch jobs submit {job_id} --location {location} --config {job_filename}".format(
+    job_id=job_id, location=REGION, job_filename=job_json_file.name
+)
+subprocess.run(cmd, shell=True)
+
+print("Job submitted with ID: {}".format(job_id))
+print("Output: {}".format(output_path))


### PR DESCRIPTION
Submitting a job by hand requires some busy-work: coming up with a job id and updating the output path to use that id.

This script automates this process by generating a job id, writing the appropriate json file, and submitting it to Batch via gcloud.

Fixes #219 

Paired with @WeihaoGe1009 