### PR TITLE
Add entrypoint scripts + pyproject.toml + install self in container

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -26,6 +26,9 @@ WORKDIR "/deepcell-imaging"
 # Install python requirements
 RUN pip install --user --upgrade -r requirements.txt
 
+# Install our own module
+RUN pip install .
+
 # The container entrypoint is the benchmark script.
 # Command-line arguments go to the script.
 ENTRYPOINT ["python", "benchmarking/deepcell-e2e/benchmark.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "deepcell-imaging"
+dynamic = ["version"]
+
+[tool.setuptools]
+packages = ["deepcell_imaging"]
+py-modules = ["__init__"] # dash, not underscore

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""
+Script to run inference on a preprocessed input image for a Mesmer model.
+
+Reads preprocessed image from a URI (typically on cloud storage).
+
+Writes model output to a URI (typically on cloud storage).
+
+The output npz has 4 arrays in it: names: arr_0, arr_1, arr_2, arr_3.
+# arr_0 and arr_1 correspond to whole-cell.
+# arr_2 and arr_3 correspond to nuclear.
+
+batch_size : string
+"""
+
+import argparse
+from deepcell_imaging import cached_open, mesmer_app
+import numpy as np
+import os
+import smart_open
+import tensorflow as tf
+import timeit
+
+parser = argparse.ArgumentParser("preprocess")
+
+parser.add_argument(
+    "--image_uri",
+    help="URI to preprocessed image npz file, containing an array named 'image'",
+    type=str,
+    required=True,
+)
+parser.add_argument(
+    "--batch_size",
+    help="Optional integer representing batch size to use for inference. Default is 16.",
+    type=int,
+    required=False,
+    default=16
+)
+parser.add_argument(
+    "--output_uri",
+    help="Where to write model output npz file containing arr_0, arr_1, arr_2, arr_3",
+    type=str,
+    required=True,
+)
+
+args = parser.parse_args()
+
+image_uri = args.image_uri
+batch_size = args.batch_size
+output_uri = args.output_uri
+
+# Hard-code remote path & hash based on model_id
+# THIS IS IN US-CENTRAL1
+# If you are running outside us-central1 you should make a copy to avoid egress.
+model_remote_path = "gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz"
+model_hash = "a1dfbce2594f927b9112f23a0a1739e0"
+
+print("Loading model")
+
+downloaded_file_path = cached_open.get_file(
+    "MultiplexSegmentation.tgz",
+    model_remote_path,
+    file_hash=model_hash,
+    extract=True,
+    cache_subdir="models",
+)
+# Remove the .tgz extension to get the model directory path
+model_path = os.path.splitext(downloaded_file_path)[0]
+
+print("Reading model from {}.".format(model_path))
+
+t = timeit.default_timer()
+model = tf.keras.models.load_model(model_path)
+model_load_time_s = timeit.default_timer() - t
+
+print("Loaded model in %s s" % model_load_time_s)
+
+print("Loading preprocessed image")
+
+t = timeit.default_timer()
+with smart_open.open(image_uri, "rb") as image_file:
+    with np.load(image_file) as loader:
+        # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
+        preprocessed_image = loader["image"]
+input_load_time_s = timeit.default_timer() - t
+
+print("Loaded preprocessed image in %s s" % input_load_time_s)
+
+print("Running inference")
+
+t = timeit.default_timer()
+model_output = mesmer_app.infer(
+    model,
+    preprocessed_image,
+    batch_size=batch_size,
+)
+infer_time_s = timeit.default_timer() - t
+
+print("Ran inference in %s s" % infer_time_s)
+
+print("Saving inference output to %s" % output_uri)
+
+t = timeit.default_timer()
+with smart_open.open(output_uri, "wb") as output_file:
+    np.savez_compressed(
+        output_file,
+        arr_0=model_output['whole-cell'][0],
+        arr_1=model_output['whole-cell'][1],
+        arr_2=model_output['nuclear'][0],
+        arr_3=model_output['nuclear'][1],
+    )
+output_time_s = timeit.default_timer() - t
+
+print("Saved output in %s s" % output_time_s)

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+"""
+Script to postprocess raw Mesmer model output back to an image.
+
+Reads raw predictions from a URI (typically on cloud storage).
+
+Writes segmented image npz to a URI (typically on cloud storage).
+"""
+
+import argparse
+from deepcell_imaging import mesmer_app
+import numpy as np
+import smart_open
+import timeit
+
+parser = argparse.ArgumentParser("preprocess")
+
+parser.add_argument(
+    "--raw_predictions_uri",
+    help="URI to model output npz file, containing 4 arrays: arr_0, arr_1, arr_2, arr_3",
+    type=str,
+    required=True,
+)
+parser.add_argument(
+    "--input_rows",
+    help="Number of rows in the input image.",
+    type=int,
+    required=True,
+)
+parser.add_argument(
+    "--input_cols",
+    help="Number of columns in the input image.",
+    type=int,
+    required=True,
+)
+parser.add_argument(
+    "--compartment",
+    help="Compartment to segment. One of 'whole-cell' (default) or 'nuclear' or 'both'.",
+    type=str,
+    required=False,
+    default="whole-cell",
+)
+parser.add_argument(
+    "--output_uri",
+    help="Where to write postprocessed segment predictions npz file containing an array named 'image'",
+    type=str,
+    required=True,
+)
+
+args = parser.parse_args()
+
+raw_predictions_uri = args.raw_predictions_uri
+input_rows = args.input_rows
+input_cols = args.input_cols
+output_uri = args.output_uri
+
+print("Loading raw predictions")
+
+t = timeit.default_timer()
+with smart_open.open(raw_predictions_uri, "rb") as raw_predictions_file:
+    with np.load(raw_predictions_file) as loader:
+        # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
+        raw_predictions = {
+            'whole-cell': [loader["arr_0"], loader["arr_1"]],
+            'nuclear': [loader["arr_2"], loader["arr_3"]],
+        }
+raw_predictions_load_time_s = timeit.default_timer() - t
+
+print("Loaded raw predictions in %s s" % raw_predictions_load_time_s)
+
+print("Postprocessing raw predictions")
+
+t = timeit.default_timer()
+predictions = mesmer_app.postprocess(
+    raw_predictions,
+    (1, input_rows, input_cols, 2),
+    compartment='whole-cell'
+)
+
+postprocessing_time_s = timeit.default_timer() - t
+
+print("Postprocessed raw predictions in %s s" % postprocessing_time_s)
+
+print("Saving output")
+
+t = timeit.default_timer()
+with smart_open.open(output_uri, "wb") as output_file:
+    np.savez_compressed(output_file, image=predictions)
+output_time_s = timeit.default_timer() - t
+
+print("Saved output in %s s" % output_time_s)

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+"""
+Script to preprocess an input image for a Mesmer model.
+
+Reads input image from a URI (typically on cloud storage).
+
+Writes preprocessed image to a URI (typically on cloud storage).
+"""
+
+import argparse
+from deepcell_imaging import mesmer_app
+import numpy as np
+import smart_open
+import timeit
+
+parser = argparse.ArgumentParser("preprocess")
+
+parser.add_argument(
+    "--image_uri",
+    help="URI to input image npz file, containing an array named 'input_channels' by default (see --image-array-name)",
+    type=str,
+    required=True,
+)
+parser.add_argument(
+    "--image_array_name",
+    help="Name of array in input image npz file, default input_channels",
+    type=str,
+    required=False,
+    default="input_channels",
+)
+parser.add_argument(
+    "--image_mpp",
+    help="Optional float representing microns per pixel of input image. Leave blank to use model's mpp",
+    type=float,
+    required=False,
+)
+parser.add_argument(
+    "--output_uri",
+    help="Where to write preprocessed input npz file containing an array named 'image'",
+    type=str,
+    required=True,
+)
+
+args = parser.parse_args()
+
+image_uri = args.image_uri
+image_array_name = args.image_array_name
+image_mpp = args.image_mpp
+output_uri = args.output_uri
+
+# This is hard-coded from the only model-id we support.
+model_input_shape = (None, 256, 256, 2)
+
+print("Loading input")
+
+t = timeit.default_timer()
+with smart_open.open(image_uri, "rb") as image_file:
+    with np.load(image_file) as loader:
+        # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
+        input_channels = loader[image_array_name]
+input_load_time_s = timeit.default_timer() - t
+
+print("Loaded input in %s s" % input_load_time_s)
+
+print("Preprocessing input")
+
+t = timeit.default_timer()
+preprocessed_image = mesmer_app.preprocess_image(
+    model_input_shape,
+    input_channels[np.newaxis, ...],
+    image_mpp=image_mpp
+)
+preprocessing_time_s = timeit.default_timer() - t
+
+print("Preprocessed input in %s s" % preprocessing_time_s)
+
+print("Saving output")
+
+t = timeit.default_timer()
+with smart_open.open(output_uri, "wb") as output_file:
+    np.savez_compressed(output_file, image=preprocessed_image)
+output_time_s = timeit.default_timer() - t
+
+print("Saved output in %s s" % output_time_s)

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+"""
+Script to preprocess an input image for a Mesmer model.
+
+Reads input image from a URI (typically on cloud storage).
+
+Writes preprocessed image to a URI (typically on cloud storage).
+"""
+
+import argparse
+from deepcell.utils.plot_utils import create_rgb_image, make_outline_overlay
+from deepcell_imaging import mesmer_app
+import numpy as np
+from PIL import Image
+import smart_open
+import timeit
+
+parser = argparse.ArgumentParser("preprocess")
+
+parser.add_argument(
+    "--image_uri",
+    help="URI to input image npz file, containing an array named 'input_channels' by default (see --image-array-name)",
+    type=str,
+    required=True,
+)
+parser.add_argument(
+    "--image_array_name",
+    help="Name of array in input image npz file, default: input_channels",
+    type=str,
+    required=False,
+    default="input_channels",
+)
+parser.add_argument(
+    "--predictions_uri",
+    help="URI to image predictions npz file, containing an array named 'image'",
+    type=str,
+    required=True,
+)
+parser.add_argument(
+    "--visualized_input_uri",
+    help="Where to write visualized input png file.",
+    type=str,
+    required=True,
+)
+parser.add_argument(
+    "--visualized_predictions_uri",
+    help="Where to write visualized predictions png file.",
+    type=str,
+    required=True,
+)
+
+args = parser.parse_args()
+
+image_uri = args.image_uri
+image_array_name = args.image_array_name
+predictions_uri = args.predictions_uri
+visualized_input_uri = args.visualized_input_uri
+visualized_predictions_uri = args.visualized_predictions_uri
+
+print("Loading input")
+
+t = timeit.default_timer()
+with smart_open.open(image_uri, "rb") as image_file:
+    with np.load(image_file) as loader:
+        # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
+        input_channels = loader[image_array_name]
+input_load_time_s = timeit.default_timer() - t
+
+print("Loaded input in %s s" % input_load_time_s)
+
+print("Loading predictions")
+
+t = timeit.default_timer()
+with smart_open.open(predictions_uri, "rb") as predictions_file:
+    with np.load(predictions_file) as loader:
+        # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
+        predictions = loader["image"]
+predictions_load_time_s = timeit.default_timer() - t
+
+print("Loaded predictions in %s s" % predictions_load_time_s)
+
+nuclear_color = "green"
+membrane_color = "blue"
+
+print("Rendering input")
+
+t = timeit.default_timer()
+
+# Create rgb overlay of image data for visualization
+# Note that this normalizes the values from "whatever" to rgb range 0..1
+input_rgb = create_rgb_image(
+    input_channels[np.newaxis, ...], channel_colors=[nuclear_color, membrane_color]
+)[0]
+
+# The png needs to normalize rgb values from 0..1, so normalize to 0..255
+im = Image.fromarray((input_rgb * 255).astype(np.uint8))
+with smart_open.open(visualized_input_uri, "wb") as input_png_file:
+    im.save(input_png_file, mode="RGB")
+
+input_render_time_s = timeit.default_timer() - t
+
+print("Rendered input in %s s" % input_render_time_s)
+
+print("Rendering predictions")
+
+t = timeit.default_timer()
+overlay_data = make_outline_overlay(
+    rgb_data=input_rgb[np.newaxis, ...],
+    predictions=predictions,
+)[0]
+
+# The rgb values are 0..1, so normalize to 0..255
+im = Image.fromarray((overlay_data * 255).astype(np.uint8))
+with smart_open.open(
+        visualized_predictions_uri, "wb"
+) as predictions_png_file:
+    im.save(predictions_png_file, mode="RGB")
+
+predictions_render_time_s = timeit.default_timer() - t
+
+print("Rendered predictions in %s s" % predictions_render_time_s)


### PR DESCRIPTION
This adds 4 independent entry point scripts:
- preprocess.py
- infer.py
- postprocess.py
- visualize.py

These implement the 3 phases plus an optional visualization step.

We added the pyproject to facilitate installing the module itself– we'll test shortly by building the container 😎

Paired with @WeihaoGe1009  

Fixes #222 