### PR TITLE
Add benchmarking output to pre/infer/post steps

### DIFF
--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -8,7 +8,8 @@ Writes segmented image npz to a URI (typically on cloud storage).
 """
 
 import argparse
-from deepcell_imaging import mesmer_app
+from deepcell_imaging import benchmark_utils, mesmer_app
+import json
 import numpy as np
 import smart_open
 import timeit
@@ -46,6 +47,12 @@ parser.add_argument(
     type=str,
     required=True,
 )
+parser.add_argument(
+    "--benchmark_output_uri",
+    help="Where to write preprocessing benchmarking data.",
+    type=str,
+    required=False,
+)
 
 args = parser.parse_args()
 
@@ -53,6 +60,7 @@ raw_predictions_uri = args.raw_predictions_uri
 input_rows = args.input_rows
 input_cols = args.input_cols
 output_uri = args.output_uri
+benchmark_output_uri = args.benchmark_output_uri
 
 print("Loading raw predictions")
 
@@ -66,26 +74,56 @@ with smart_open.open(raw_predictions_uri, "rb") as raw_predictions_file:
         }
 raw_predictions_load_time_s = timeit.default_timer() - t
 
-print("Loaded raw predictions in %s s" % raw_predictions_load_time_s)
+print("Loaded raw predictions in %s s" % round(raw_predictions_load_time_s, 2))
 
 print("Postprocessing raw predictions")
 
 t = timeit.default_timer()
-predictions = mesmer_app.postprocess(
-    raw_predictions,
-    (1, input_rows, input_cols, 2),
-    compartment='whole-cell'
-)
+try:
+    segmentation = mesmer_app.postprocess(
+        raw_predictions,
+        (1, input_rows, input_cols, 2),
+        compartment='whole-cell'
+    )
+    success = True
+except Exception as e:
+    print("Postprocessing failed with error: %s" % e)
+    success = False
 
 postprocessing_time_s = timeit.default_timer() - t
 
-print("Postprocessed raw predictions in %s s" % postprocessing_time_s)
+print("Postprocessed raw predictions in %s s; success: %s" % (round(postprocessing_time_s, 2), success))
 
-print("Saving output")
+if success:
+    print("Saving output")
+    t = timeit.default_timer()
+    with smart_open.open(output_uri, "wb") as output_file:
+        np.savez_compressed(output_file, image=segmentation)
+    output_time_s = timeit.default_timer() - t
+    print("Saved output in %s s" % round(output_time_s, 2))
+else:
+    print("Not saving failed postprocessing output.")
+    output_time_s = 0.0
 
-t = timeit.default_timer()
-with smart_open.open(output_uri, "wb") as output_file:
-    np.savez_compressed(output_file, image=predictions)
-output_time_s = timeit.default_timer() - t
 
-print("Saved output in %s s" % output_time_s)
+# Gather & output timing information
+
+if benchmark_output_uri:
+    gpu_info = benchmark_utils.get_gpu_info()
+
+    timing_info = {
+        "postprocessing_instance_type": benchmark_utils.get_gce_instance_type(),
+        "postprocessing_gpu_type": gpu_info[0],
+        "postprocessing_num_gpus": gpu_info[1],
+        "postprocessing_success": success,
+        "postprocessing_peak_memory_gb": benchmark_utils.get_peak_memory(),
+        "postprocessing_is_preemptible": benchmark_utils.get_gce_is_preemptible(),
+        "prediction_input_load_time_s": raw_predictions_load_time_s,
+        "postprocessing_time_s": postprocessing_time_s,
+        "postprocessing_output_write_time_s": output_time_s,
+    }
+
+    with smart_open.open(benchmark_output_uri, "w") as benchmark_output_file:
+        json.dump(timing_info, benchmark_output_file)
+
+    print("Wrote benchmarking data to %s" % benchmark_output_uri)


### PR DESCRIPTION
Output benchmarking data to an optional JSON file at the end of each step.

Also, round times to 2 decimal places.

Part of #238 but does not complete it. (We need to test, plus add a final step to gather all benchmarking data & write to BigQuery.)

Paired with @WeihaoGe1009 