### PR TITLE
Fetch input image size from remote file (don't hardcode)

### DIFF
--- a/batch/run-multistep-job.py
+++ b/batch/run-multistep-job.py
@@ -38,117 +38,117 @@ input_image_shape = input_file_contents[0][1]
 # Need to escape the curly braces in the JSON template
 base_json = """
 {{
-    "taskGroups": [
-        {{
-            "taskSpec": {{
-                "runnables": [
-                    {{
-                        "container": {{
-                            "imageUri": "{container_image}",
-                            "entrypoint": "python",
-                            "commands": [
-                                "scripts/preprocess.py",
-                                "--image_uri={input_channels_path}",
-                                "--benchmark_output_uri={output_path}/preprocess_benchmark.json",
-                                "--output_uri={output_path}/preprocessed.npz"
-                            ]
-                        }}
-                    }},
-                    {{
-                        "container": {{
-                            "imageUri": "{container_image}",
-                            "entrypoint": "python",
-                            "commands": [
-                                "scripts/predict.py",
-                                "--image_uri={output_path}/preprocessed.npz",
-                                "--benchmark_output_uri={output_path}/prediction_benchmark.json",
-                                "--output_uri={output_path}/raw_predictions.npz"
-                            ]
-                        }}
-                    }},
-                    {{
-                        "container": {{
-                            "imageUri": "{container_image}",
-                            "entrypoint": "python",
-                            "commands": [
-                                "scripts/postprocess.py",
-                                "--raw_predictions_uri={output_path}/raw_predictions.npz",
-                                "--input_rows={input_image_rows}",
-                                "--input_cols={input_image_cols}",
-                                "--benchmark_output_uri={output_path}/postprocess_benchmark.json",
-                                "--output_uri={output_path}/predictions.npz"
-                            ]
-                        }}
-                    }},
-                    {{
-                        "container": {{
-                            "imageUri": "{container_image}",
-                            "entrypoint": "python",
-                            "commands": [
-                                "scripts/gather-benchmark.py",
-                                "--preprocess_benchmarking_uri={output_path}/preprocess_benchmark.json",
-                                "--prediction_benchmarking_uri={output_path}/prediction_benchmark.json",
-                                "--postprocess_benchmarking_uri={output_path}/postprocess_benchmark.json",
-                                "--bigquery_benchmarking_table=deepcell-on-batch.benchmarking.results_batch"
-                            ]
-                        }}
-                    }},
-                    {{
-                        "container": {{
-                            "imageUri": "{container_image}",
-                            "entrypoint": "python",
-                            "commands": [
-                                "scripts/visualize.py",
-                                "--image_uri={input_channels_path}",
-                                "--predictions_uri={output_path}/predictions.npz",
-                                "--visualized_input_uri={output_path}/visualized_input.png",
-                                "--visualized_predictions_uri={output_path}/visualized_predictions.png"
-                            ]
-                        }}
-                    }}
-                ],
-                "computeResource": {{
-                    "memoryMib": 26000
-                }},
-                "maxRetryCount": 3,
-                "lifecyclePolicies": [
-                  {{
-                    "action": "RETRY_TASK",
-                    "actionCondition": {{
-                      "exitCodes": [50001]
-                    }}
-                  }}
-                ]
-            }},
-            "taskCount": 1,
-            "parallelism": 1
-        }}
-    ],
-    "allocationPolicy": {{
-        "instances": [
-            {{
-                "installGpuDrivers": true,
-                "policy": {{
-                  "machineType": "n1-standard-8",
-                  "provisioningModel": "SPOT",
-                    "accelerators": [
-                        {{
-                            "type": "nvidia-tesla-t4",
-                            "count": 1
-                        }}
-                    ]
-                }}
+  "taskGroups": [
+    {{
+      "taskSpec": {{
+        "runnables": [
+          {{
+            "container": {{
+              "imageUri": "{container_image}",
+              "entrypoint": "python",
+              "commands": [
+                "scripts/preprocess.py",
+                "--image_uri={input_channels_path}",
+                "--benchmark_output_uri={output_path}/preprocess_benchmark.json",
+                "--output_uri={output_path}/preprocessed.npz"
+              ]
             }}
+          }},
+          {{
+            "container": {{
+              "imageUri": "{container_image}",
+              "entrypoint": "python",
+              "commands": [
+                "scripts/predict.py",
+                "--image_uri={output_path}/preprocessed.npz",
+                "--benchmark_output_uri={output_path}/prediction_benchmark.json",
+                "--output_uri={output_path}/raw_predictions.npz"
+              ]
+            }}
+          }},
+          {{
+            "container": {{
+              "imageUri": "{container_image}",
+              "entrypoint": "python",
+              "commands": [
+                "scripts/postprocess.py",
+                "--raw_predictions_uri={output_path}/raw_predictions.npz",
+                "--input_rows={input_image_rows}",
+                "--input_cols={input_image_cols}",
+                "--benchmark_output_uri={output_path}/postprocess_benchmark.json",
+                "--output_uri={output_path}/predictions.npz"
+              ]
+            }}
+          }},
+          {{
+            "container": {{
+              "imageUri": "{container_image}",
+              "entrypoint": "python",
+              "commands": [
+                "scripts/gather-benchmark.py",
+                "--preprocess_benchmarking_uri={output_path}/preprocess_benchmark.json",
+                "--prediction_benchmarking_uri={output_path}/prediction_benchmark.json",
+                "--postprocess_benchmarking_uri={output_path}/postprocess_benchmark.json",
+                "--bigquery_benchmarking_table=deepcell-on-batch.benchmarking.results_batch"
+              ]
+            }}
+          }},
+          {{
+            "container": {{
+              "imageUri": "{container_image}",
+              "entrypoint": "python",
+              "commands": [
+                "scripts/visualize.py",
+                "--image_uri={input_channels_path}",
+                "--predictions_uri={output_path}/predictions.npz",
+                "--visualized_input_uri={output_path}/visualized_input.png",
+                "--visualized_predictions_uri={output_path}/visualized_predictions.png"
+              ]
+            }}
+          }}
         ],
-        "location": {{
-            "allowedLocations": [
-                "regions/{region}"
-            ]
-        }}
-    }},
-    "logsPolicy": {{
-        "destination": "CLOUD_LOGGING"
+        "computeResource": {{
+          "memoryMib": 26000
+        }},
+        "maxRetryCount": 3,
+        "lifecyclePolicies": [
+          {{
+            "action": "RETRY_TASK",
+            "actionCondition": {{
+              "exitCodes": [50001]
+            }}
+          }}
+        ]
+      }},
+      "taskCount": 1,
+      "parallelism": 1
     }}
+  ],
+  "allocationPolicy": {{
+    "instances": [
+      {{
+        "installGpuDrivers": true,
+        "policy": {{
+          "machineType": "n1-standard-8",
+          "provisioningModel": "SPOT",
+          "accelerators": [
+            {{
+              "type": "nvidia-tesla-t4",
+              "count": 1
+            }}
+          ]
+        }}
+      }}
+    ],
+    "location": {{
+      "allowedLocations": [
+        "regions/{region}"
+      ]
+    }}
+  }},
+  "logsPolicy": {{
+    "destination": "CLOUD_LOGGING"
+  }}
 }}
 """
 

--- a/batch/run-multistep-job.py
+++ b/batch/run-multistep-job.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import tempfile
+import uuid
+
+from deepcell_imaging.numpy_utils import npz_headers
+
+parser = argparse.ArgumentParser("deepcell-on-batch")
+parser.add_argument(
+    "--input_channels_path",
+    help="Path to the input channels npz file",
+    type=str,
+    required=True,
+)
+
+args = parser.parse_args()
+
+job_id = "j" + str(uuid.uuid4())
+input_channels_path = args.input_channels_path
+
+CONTAINER_IMAGE = "us-central1-docker.pkg.dev/deepcell-on-batch/deepcell-benchmarking-us-central1/benchmarking:gce"
+OUTPUT_BASE_PATH = "gs://deepcell-batch-jobs_us-central1/job-runs"
+REGION = "us-central1"
+
+output_path = "{}/{}".format(OUTPUT_BASE_PATH, job_id)
+
+# For now, assume there's only one file in the input.
+input_file_contents = list(npz_headers(input_channels_path))
+if len(input_file_contents) != 1:
+    raise ValueError("Expected exactly one array in the input file")
+input_image_shape = input_file_contents[0][1]
+
+# A lot of stuff gets hardcoded in this json.
+# See the README for limitations.
+
+# Need to escape the curly braces in the JSON template
+base_json = """
+{{
+    "taskGroups": [
+        {{
+            "taskSpec": {{
+                "runnables": [
+                    {{
+                        "container": {{
+                            "imageUri": "{container_image}",
+                            "entrypoint": "python",
+                            "commands": [
+                                "scripts/preprocess.py",
+                                "--image_uri={input_channels_path}",
+                                "--benchmark_output_uri={output_path}/preprocess_benchmark.json",
+                                "--output_uri={output_path}/preprocessed.npz"
+                            ]
+                        }}
+                    }},
+                    {{
+                        "container": {{
+                            "imageUri": "{container_image}",
+                            "entrypoint": "python",
+                            "commands": [
+                                "scripts/predict.py",
+                                "--image_uri={output_path}/preprocessed.npz",
+                                "--benchmark_output_uri={output_path}/prediction_benchmark.json",
+                                "--output_uri={output_path}/raw_predictions.npz"
+                            ]
+                        }}
+                    }},
+                    {{
+                        "container": {{
+                            "imageUri": "{container_image}",
+                            "entrypoint": "python",
+                            "commands": [
+                                "scripts/postprocess.py",
+                                "--raw_predictions_uri={output_path}/raw_predictions.npz",
+                                "--input_rows={input_image_rows}",
+                                "--input_cols={input_image_cols}",
+                                "--benchmark_output_uri={output_path}/postprocess_benchmark.json",
+                                "--output_uri={output_path}/predictions.npz"
+                            ]
+                        }}
+                    }},
+                    {{
+                        "container": {{
+                            "imageUri": "{container_image}",
+                            "entrypoint": "python",
+                            "commands": [
+                                "scripts/gather-benchmark.py",
+                                "--preprocess_benchmarking_uri={output_path}/preprocess_benchmark.json",
+                                "--prediction_benchmarking_uri={output_path}/prediction_benchmark.json",
+                                "--postprocess_benchmarking_uri={output_path}/postprocess_benchmark.json",
+                                "--bigquery_benchmarking_table=deepcell-on-batch.benchmarking.results_batch"
+                            ]
+                        }}
+                    }},
+                    {{
+                        "container": {{
+                            "imageUri": "{container_image}",
+                            "entrypoint": "python",
+                            "commands": [
+                                "scripts/visualize.py",
+                                "--image_uri={input_channels_path}",
+                                "--predictions_uri={output_path}/predictions.npz",
+                                "--visualized_input_uri={output_path}/visualized_input.png",
+                                "--visualized_predictions_uri={output_path}/visualized_predictions.png"
+                            ]
+                        }}
+                    }}
+                ],
+                "computeResource": {{
+                    "memoryMib": 26000
+                }},
+                "maxRetryCount": 3,
+                "lifecyclePolicies": [
+                  {{
+                    "action": "RETRY_TASK",
+                    "actionCondition": {{
+                      "exitCodes": [50001]
+                    }}
+                  }}
+                ]
+            }},
+            "taskCount": 1,
+            "parallelism": 1
+        }}
+    ],
+    "allocationPolicy": {{
+        "instances": [
+            {{
+                "installGpuDrivers": true,
+                "policy": {{
+                  "machineType": "n1-standard-8",
+                  "provisioningModel": "SPOT",
+                    "accelerators": [
+                        {{
+                            "type": "nvidia-tesla-t4",
+                            "count": 1
+                        }}
+                    ]
+                }}
+            }}
+        ],
+        "location": {{
+            "allowedLocations": [
+                "regions/{region}"
+            ]
+        }}
+    }},
+    "logsPolicy": {{
+        "destination": "CLOUD_LOGGING"
+    }}
+}}
+"""
+
+#    "labels": {{
+#        "goog-batch-job-group": "my-test-pool",
+#        "goog-batch-node-pool-max-idle-time": "20min",
+#        "goog-batch-node-pool-max-size": "4"
+#    }},
+
+job_json_str = base_json.format(
+    output_path=output_path,
+    input_channels_path=input_channels_path,
+    container_image=CONTAINER_IMAGE,
+    region=REGION,
+    input_image_rows=input_image_shape[0],
+    input_image_cols=input_image_shape[1],
+)
+
+job_json_file = tempfile.NamedTemporaryFile()
+with open(job_json_file.name, "w") as f:
+    f.write(job_json_str)
+
+cmd = "gcloud batch jobs submit {job_id} --location {location} --config {job_filename}".format(
+    job_id=job_id, location=REGION, job_filename=job_json_file.name
+)
+subprocess.run(cmd, shell=True)
+
+print("Job submitted with ID: {}".format(job_id))
+print("Output: {}".format(output_path))

--- a/deepcell_imaging/mesmer_app.py
+++ b/deepcell_imaging/mesmer_app.py
@@ -96,7 +96,7 @@ def preprocess_image(model_input_shape, image, image_mpp):
     return image
 
 
-def infer(model, image, batch_size):
+def predict(model, image, batch_size):
     logger = logging.getLogger(__name__)
     model_image_shape = model.input_shape[1:]
     pad_mode = 'constant'
@@ -112,7 +112,7 @@ def infer(model, image, batch_size):
         model=model, tiles=tiles, batch_size=batch_size
     )
     logger.debug(
-        "Model inference finished in %s s", timeit.default_timer() - t
+        "Model prediction finished in %s s", timeit.default_timer() - t
     )
 
     # Untile images

--- a/deepcell_imaging/numpy_utils.py
+++ b/deepcell_imaging/numpy_utils.py
@@ -1,0 +1,20 @@
+import numpy as np
+import smart_open
+import zipfile
+
+
+# Adapted from: https://stackoverflow.com/questions/35990775/finding-shape-of-saved-numpy-array-npy-or-npz-without-loading-into-memory
+# (Added smart_open wrapper for streaming remote access)
+def npz_headers(npz):
+    """Takes a path to an .npz file, which is a Zip archive of .npy files.
+    Generates a sequence of (name, shape, np.dtype).
+    """
+    with zipfile.ZipFile(smart_open.open(npz, mode='rb')) as archive:
+        for name in archive.namelist():
+            if not name.endswith('.npy'):
+                continue
+
+            npy = archive.open(name)
+            version = np.lib.format.read_magic(npy)
+            shape, fortran, dtype = np.lib.format._read_array_header(npy, version)
+            yield name[:-4], shape, dtype

--- a/run-sample.py
+++ b/run-sample.py
@@ -16,7 +16,7 @@ with smart_open.open(input_channels_path, "rb") as input_channel_file:
 
 model = tf.keras.models.load_model(mesmer_app.model_path)
 preprocessed_image = mesmer_app.preprocess_image(model.input_shape, input_channels[np.newaxis, ...], image_mpp=None)
-inferred_images = mesmer_app.infer(model, preprocessed_image, batch_size=4)
+inferred_images = mesmer_app.predict(model, preprocessed_image, batch_size=4)
 predictions = mesmer_app.postprocess(inferred_images, input_channels[np.newaxis, ...].shape, compartment='whole-cell')
 
 print(input_channels.shape)

--- a/scripts/gather-benchmark.py
+++ b/scripts/gather-benchmark.py
@@ -25,8 +25,8 @@ parser.add_argument(
     required=True,
 )
 parser.add_argument(
-    "--infer_benchmarking_uri",
-    help="URI to benchmarking data for the inference step.",
+    "--prediction_benchmarking_uri",
+    help="URI to benchmarking data for the prediction step.",
     type=str,
     required=True,
 )
@@ -46,7 +46,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 preprocess_benchmarking_uri = args.preprocess_benchmarking_uri
-infer_benchmarking_uri = args.infer_benchmarking_uri
+prediction_benchmarking_uri = args.prediction_benchmarking_uri
 postprocess_benchmarking_uri = args.postprocess_benchmarking_uri
 bigquery_benchmarking_table = args.bigquery_benchmarking_table
 
@@ -58,7 +58,7 @@ print("Loading benchmarking data")
 
 t = timeit.default_timer()
 
-for data_uri in [preprocess_benchmarking_uri, infer_benchmarking_uri, postprocess_benchmarking_uri]:
+for data_uri in [preprocess_benchmarking_uri, prediction_benchmarking_uri, postprocess_benchmarking_uri]:
     with smart_open.open(data_uri, "r") as data_file:
         data = json.load(data_file)
         benchmarking_data.update(data)

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Script to run inference on a preprocessed input image for a Mesmer model.
+Script to run prediction on a preprocessed input image for a Mesmer model.
 
 Reads preprocessed image from a URI (typically on cloud storage).
 
@@ -32,7 +32,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--batch_size",
-    help="Optional integer representing batch size to use for inference. Default is 16.",
+    help="Optional integer representing batch size to use for prediction. Default is 16.",
     type=int,
     required=False,
     default=16
@@ -94,11 +94,11 @@ input_load_time_s = timeit.default_timer() - t
 
 print("Loaded preprocessed image in %s s" % round(input_load_time_s, 2))
 
-print("Running inference")
+print("Running prediction")
 
 t = timeit.default_timer()
 try:
-    model_output = mesmer_app.infer(
+    model_output = mesmer_app.predict(
         model,
         preprocessed_image,
         batch_size=batch_size,
@@ -106,14 +106,14 @@ try:
     success = True
 except Exception as e:
     success = False
-    print("Inference failed with error: %s" % e)
+    print("Prediction failed with error: %s" % e)
 
-infer_time_s = timeit.default_timer() - t
+predict_time_s = timeit.default_timer() - t
 
-print("Ran inference in %s s; success: %s" % (round(infer_time_s, 2), success))
+print("Ran prediction in %s s; success: %s" % (round(predict_time_s, 2), success))
 
 if success:
-    print("Saving inference output to %s" % output_uri)
+    print("Saving raw predictions output to %s" % output_uri)
 
     t = timeit.default_timer()
     with smart_open.open(output_uri, "wb") as output_file:
@@ -128,7 +128,7 @@ if success:
 
     print("Saved output in %s s" % round(output_time_s, 2))
 else:
-    print("Not saving failed inference output.")
+    print("Not saving failed prediction output.")
     output_time_s = 0.0
 
 # Gather & output timing information
@@ -146,7 +146,7 @@ if benchmark_output_uri:
         "prediction_model_load_time_s": model_load_time_s,
         "prediction_input_load_time_s": input_load_time_s,
         "prediction_batch_size": batch_size,
-        "prediction_time_s": infer_time_s,
+        "prediction_time_s": predict_time_s,
         "prediction_output_write_time_s": output_time_s,
     }
 


### PR DESCRIPTION
Fixes issue #240. See issue for more context. TLDR: we need to provide the input size to postprocessing to resize back to original if necessary. We were passing in hard-coded 512x512. Now we fetch the numpy headers and use those to set the size.

Paired with @WeihaoGe1009 