### PR TITLE
Use gcloud storage cp instead of Python API

### DIFF
--- a/deepcell_imaging/gcloud_storage_utils.py
+++ b/deepcell_imaging/gcloud_storage_utils.py
@@ -1,0 +1,42 @@
+
+import io
+import numpy as np
+import os
+import subprocess
+import tempfile
+
+
+def fetch_file(gs_uri):
+    """
+    Fetch a file from Google Cloud Storage using its URI.
+
+    Returns it as a BytesIO object.
+
+    Under the hood, calls out to the `gcloud storage` command-line tool,
+    which has optimized performance for large data transfers (for example,
+    parallel/chunked transfers).
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, 'downloaded_file')
+
+        # TODO: handle errors
+        subprocess.run(["gcloud", "storage", "cp", gs_uri, path])
+
+        with open(path, 'rb') as f:
+            return io.BytesIO(f.read())
+
+
+def write_npz_file(gs_uri, **named_arrays):
+    """
+    Write a BytesIO object to Google Cloud Storage using its URI.
+
+    Under the hood, calls out to the `gcloud storage` command-line tool,
+    which has optimized performance for large data transfers (for example,
+    parallel/chunked transfers).
+    """
+    with tempfile.NamedTemporaryFile() as tmp:
+        np.savez_compressed(tmp, **named_arrays)
+        tmp.flush()
+
+        # TODO: handle errors
+        subprocess.run(["gcloud", "storage", "cp", tmp.name, gs_uri])

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+tmp_preprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/preprocessed.npz"
+tmp_predict_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/raw_predictions.npz"
+tmp_postprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/postprocessed.npz"
+
+input_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/input.png"
+predictions_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/predictions.png"
+
+python scripts/preprocess.py --image_uri $1 --output_uri $tmp_preprocess_output
+python scripts/predict.py --image_uri $tmp_preprocess_output --output_uri $tmp_predict_output
+python scripts/postprocess.py --raw_predictions_uri $tmp_predict_output --output_uri $tmp_postprocess_output --input_rows 512 --input_cols 512
+python scripts/visualize.py --image_uri $1 --predictions_uri $tmp_postprocess_output --visualized_input_uri $input_png_uri --visualized_predictions_uri $predictions_png_uri
+
+

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -14,7 +14,7 @@ import numpy as np
 import smart_open
 import timeit
 
-parser = argparse.ArgumentParser("preprocess")
+parser = argparse.ArgumentParser("postprocess")
 
 parser.add_argument(
     "--raw_predictions_uri",

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -22,7 +22,7 @@ import smart_open
 import tensorflow as tf
 import timeit
 
-parser = argparse.ArgumentParser("preprocess")
+parser = argparse.ArgumentParser("predict")
 
 parser.add_argument(
     "--image_uri",

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -14,7 +14,7 @@ batch_size : string
 """
 
 import argparse
-from deepcell_imaging import benchmark_utils, cached_open, mesmer_app
+from deepcell_imaging import benchmark_utils, cached_open, gcloud_storage_utils, mesmer_app
 import json
 import numpy as np
 import os
@@ -86,10 +86,9 @@ print("Loaded model in %s s" % round(model_load_time_s, 2))
 print("Loading preprocessed image")
 
 t = timeit.default_timer()
-with smart_open.open(image_uri, "rb") as image_file:
-    with np.load(image_file) as loader:
-        # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
-        preprocessed_image = loader["image"]
+
+with np.load(gcloud_storage_utils.fetch_file(image_uri)) as loader:
+    preprocessed_image = loader["image"]
 input_load_time_s = timeit.default_timer() - t
 
 print("Loaded preprocessed image in %s s" % round(input_load_time_s, 2))
@@ -116,14 +115,13 @@ if success:
     print("Saving raw predictions output to %s" % output_uri)
 
     t = timeit.default_timer()
-    with smart_open.open(output_uri, "wb") as output_file:
-        np.savez_compressed(
-            output_file,
-            arr_0=model_output['whole-cell'][0],
-            arr_1=model_output['whole-cell'][1],
-            arr_2=model_output['nuclear'][0],
-            arr_3=model_output['nuclear'][1],
-        )
+    gcloud_storage_utils.write_npz_file(
+        output_uri,
+        arr_0=model_output['whole-cell'][0],
+        arr_1=model_output['whole-cell'][1],
+        arr_2=model_output['nuclear'][0],
+        arr_3=model_output['nuclear'][1],
+    )
     output_time_s = timeit.default_timer() - t
 
     print("Saved output in %s s" % round(output_time_s, 2))

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -15,7 +15,7 @@ from PIL import Image
 import smart_open
 import timeit
 
-parser = argparse.ArgumentParser("preprocess")
+parser = argparse.ArgumentParser("visualize")
 
 parser.add_argument(
     "--image_uri",
@@ -82,7 +82,7 @@ print("Loaded predictions in %s s" % predictions_load_time_s)
 nuclear_color = "green"
 membrane_color = "blue"
 
-print("Rendering input")
+print("Rendering input to %s" % visualized_input_uri)
 
 t = timeit.default_timer()
 
@@ -101,7 +101,7 @@ input_render_time_s = timeit.default_timer() - t
 
 print("Rendered input in %s s" % input_render_time_s)
 
-print("Rendering predictions")
+print("Rendering predictions to %s" % visualized_predictions_uri)
 
 t = timeit.default_timer()
 overlay_data = make_outline_overlay(

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -9,7 +9,7 @@ Writes preprocessed image to a URI (typically on cloud storage).
 
 import argparse
 from deepcell.utils.plot_utils import create_rgb_image, make_outline_overlay
-from deepcell_imaging import mesmer_app
+from deepcell_imaging import gcloud_storage_utils
 import numpy as np
 from PIL import Image
 import smart_open
@@ -60,10 +60,9 @@ visualized_predictions_uri = args.visualized_predictions_uri
 print("Loading input")
 
 t = timeit.default_timer()
-with smart_open.open(image_uri, "rb") as image_file:
-    with np.load(image_file) as loader:
-        # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
-        input_channels = loader[image_array_name]
+with np.load(gcloud_storage_utils.fetch_file(image_uri)) as loader:
+    # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
+    input_channels = loader[image_array_name]
 input_load_time_s = timeit.default_timer() - t
 
 print("Loaded input in %s s" % input_load_time_s)
@@ -71,10 +70,9 @@ print("Loaded input in %s s" % input_load_time_s)
 print("Loading predictions")
 
 t = timeit.default_timer()
-with smart_open.open(predictions_uri, "rb") as predictions_file:
-    with np.load(predictions_file) as loader:
-        # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
-        predictions = loader["image"]
+with np.load(gcloud_storage_utils.fetch_file(predictions_uri)) as loader:
+    # An array of shape [height, width, channel] containing intensity of nuclear & membrane channels
+    predictions = loader["image"]
 predictions_load_time_s = timeit.default_timer() - t
 
 print("Loaded predictions in %s s" % predictions_load_time_s)


### PR DESCRIPTION
The Python API is ~80% slower than gcloud storage cp (which uses parallelization and other tricks).

This switches most of our I/O to gcloud storage cp. We didn't convert:

- model download. (Uses the cached_open library, which we control but didn't feel like doing yet)
- visualization. (Writes images, not numpy, need to generalize to byte streams or something)

Fixes #248.

Paired with @WeihaoGe1009 