### PR TITLE
Use pigz and add gcloud storage to container

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -9,10 +9,13 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 # Update installed packages & install graphviz & git
 # Clear out the aptitude cache as well.
 # Lastly, install and/or update pip.
-RUN apt-get update && \
-    apt-get install -y graphviz git && \
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update -y && \
+    apt-get install -y graphviz git google-cloud-sdk google-cloud-cli pigz && \
     rm -rf /var/lib/apt/lists/* && \
-    /usr/bin/python3 -m pip install --no-cache-dir --upgrade pip
+    /usr/bin/python3 -m pip install --no-cache-dir --upgrade pip && \
+    gcloud config set storage/parallel_composite_upload_enabled True
 
 # Add the repo sha to the container as the version.
 ADD https://api.github.com/repos/dchaley/deepcell-imaging/git/refs/heads/main version.json

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-tmp_preprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/preprocessed.npz"
-tmp_predict_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/raw_predictions.npz"
-tmp_postprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/postprocessed.npz"
+tmp_preprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/preprocessed.npz.gz"
+tmp_predict_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/raw_predictions.npz.gz"
+tmp_postprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/postprocessed.npz.gz"
 
 input_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/input.png"
 predictions_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/predictions.png"


### PR DESCRIPTION
It seems that pigz (multi-threaded/processed gzip) is order(s) of magnitude faster than numpy savez_compressed.

Support .gz remote links, and compress/decompress using pigz/unpigz as necessary.