### PR TITLE
Switch from building on GitHub Actions to Cloud Build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,6 @@ jobs:
       - name: "Use gcloud CLI"
         run: "gcloud info"
 
-      - name: "Docker auth"
-        run: |-
-          gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
-
-      - name: Build image
-        run: docker build . --file Dockerfile --tag ${{ env.GAR_LOCATION }}
+      - name: Trigger cloud build
+        run: ./cloud-build.sh
         working-directory: container
-
-      - name: Push image
-        run: docker push ${{ env.GAR_LOCATION }}


### PR DESCRIPTION
Invoke cloud build in the GCP project, rather than build here.

That means we'll need a way to move the container from Google to Docker Hub. Previously, we'd have simply pushed the container we just built to both.