### PR TITLE
Push builds to GCP Artifact Registry and Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,5 +31,5 @@ jobs:
         run: "gcloud info"
 
       - name: Trigger cloud build
-        run: ./cloud-build.sh
+        run: "gcloud builds submit --region=us-central1 --config=build-batch-container.yaml ."
         working-directory: container

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update -y && \
-    apt-get install -y graphviz git google-cloud-sdk google-cloud-cli pigz && \
+    apt-get install -y git google-cloud-sdk google-cloud-cli pigz && \
     rm -rf /var/lib/apt/lists/* && \
     /usr/bin/python3 -m pip install --no-cache-dir --upgrade pip && \
     gcloud config set storage/parallel_composite_upload_enabled True

--- a/container/build-batch-container.yaml
+++ b/container/build-batch-container.yaml
@@ -1,0 +1,22 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: [ '-c', 'echo "$$PASSWORD" | docker login --username=$$USERNAME --password-stdin' ]
+    secretEnv: [ 'USERNAME', 'PASSWORD' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [
+      'build',
+      '-t', 'us-central1-docker.pkg.dev/deepcell-on-batch/deepcell-benchmarking-us-central1/benchmarking:batch',
+      '-t', 'dchaley/deepcell-imaging:batch',
+      '.',
+    ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'push', 'us-central1-docker.pkg.dev/deepcell-on-batch/deepcell-benchmarking-us-central1/benchmarking:batch' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'push', 'dchaley/deepcell-imaging:batch' ]
+availableSecrets:
+  secretManager:
+    - versionName: projects/deepcell-on-batch/secrets/dockerhub-password/versions/1
+      env: 'PASSWORD'
+    - versionName: projects/deepcell-on-batch/secrets/dockerhub-username/versions/2
+      env: 'USERNAME'


### PR DESCRIPTION
Set up a build config that pushes the container to both private Artifact Registry & public Docker Hub.

Redirects the GitHub actions workflow to use this new config.

While we're here, remove graphviz from container dependencies– this should save on fonts & stuff, I think we got it from copy/pasta.