### PR TITLE
Use gcloud_storage_utils for writing TIFF to GCP

### DIFF
--- a/benchmarking/deepcell-e2e/benchmark.py
+++ b/benchmarking/deepcell-e2e/benchmark.py
@@ -15,13 +15,12 @@ import psutil
 import re
 import resource
 import smart_open
-import sys
 from tenacity import retry, retry_if_exception_message, wait_random_exponential
 import traceback
 import timeit
 import urllib.parse
 
-from deepcell_imaging import cached_open
+from deepcell_imaging import cached_open, gcloud_storage_utils
 
 BIGQUERY_RESULTS_TABLE = "deepcell-401920.benchmarking.results_batch"
 
@@ -235,8 +234,14 @@ if output_path:
 
     if output_tiff:
         import tifffile
-        with smart_open.open("%s/predictions.tiff" % output_path, "wb") as predictions_tiff_file:
-            tifffile.imwrite(predictions_tiff_file, np.squeeze(segmentation_predictions) if squeeze_output_tiff else segmentation_predictions)
+        data_to_write = np.squeeze(segmentation_predictions) if squeeze_output_tiff else segmentation_predictions
+        # smart_open doesn't support seeking on GCP, which tifffile uses.
+        if output_path.startswith("gs://"):
+            with gcloud_storage_utils.writer("%s/predictions.tiff" % output_path) as predictions_tiff_file:
+                tifffile.imwrite(predictions_tiff_file, data_to_write)
+        else:
+            with smart_open.open("%s/predictions.tiff" % output_path, "wb") as predictions_tiff_file:
+                tifffile.imwrite(predictions_tiff_file, data_to_write)
 
 if visualize_input or visualize_predictions:
     from deepcell.utils.plot_utils import create_rgb_image

--- a/benchmarking/deepcell-e2e/benchmark.py
+++ b/benchmarking/deepcell-e2e/benchmark.py
@@ -234,6 +234,7 @@ if output_path:
 
     if output_tiff:
         import tifffile
+
         data_to_write = np.squeeze(segmentation_predictions) if squeeze_output_tiff else segmentation_predictions
         # smart_open doesn't support seeking on GCP, which tifffile uses.
         if output_path.startswith("gs://"):
@@ -274,7 +275,7 @@ if visualize_predictions:
     # The rgb values are 0..1, so normalize to 0..255
     im = Image.fromarray((overlay_data * 255).astype(np.uint8))
     with smart_open.open(
-        "%s/predictions.png" % output_path, "wb"
+            "%s/predictions.png" % output_path, "wb"
     ) as predictions_png_file:
         im.save(predictions_png_file, mode="RGB")
 
@@ -417,7 +418,7 @@ else:
 peak_mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 
 prediction_overhead_s = (
-    prediction_time_s - preprocess_time_s - inference_time_s - postprocess_time_s
+        prediction_time_s - preprocess_time_s - inference_time_s - postprocess_time_s
 )
 
 if gpu_count == 0:


### PR DESCRIPTION
The smart_open API seems to not support file seeking, which tifffile uses. (See also #253)

We already have gcloud_storage_utils which buffers to a local file before using the `gcloud` CLI to upload (it's a lot more performant). That means, it has access to normal file seeking.

And we get a performance boost for large prediction TIFFs, yay 😎 