### PR TITLE
Remote output squeeze option

### DIFF
--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -54,11 +54,6 @@ parser.add_argument(
     required=False,
 )
 parser.add_argument(
-    "--squeeze_output_tiff",
-    help="If true, remove axes of length 1 from predictions before writing the output tiff.",
-    action="store_true",
-)
-parser.add_argument(
     "--benchmark_output_uri",
     help="Where to write preprocessing benchmarking data.",
     type=str,


### PR DESCRIPTION
The DeepCell code I copied provided the option to "np.squeeze" the output, aka remove axes of length one. Something like:

`(1, 512, 512, 1)`    (one 512x512 image w/ 1 channel value)

becomes

`(512, 512)` (512x512 pixel values)

But, turns out [we don't need it](https://github.com/dchaley/deepcell-imaging/issues/253#issuecomment-2206531897).

So ... let's get rid of it 👋🏻

We still need to resolve the question of batch dimension or not. We currently do not output the batch dimension. We output: 512x512x1