### PR TITLE
Add model_path and model_hash arguments to run-multistep-job

### DIFF
--- a/batch/run-multistep-job.py
+++ b/batch/run-multistep-job.py
@@ -16,10 +16,24 @@ parser.add_argument(
 )
 parser.add_argument(
     "--bigquery_benchmarking_table",
-    help="BigQuery table to write benchmarking results to",
+    help="BigQuery table to write benchmarking results to (empty for none)",
     type=str,
     required=False,
     default="deepcell-on-batch.benchmarking.results_batch",
+)
+parser.add_argument(
+    "--model_path",
+    help="Path to the model archive",
+    type=str,
+    required=False,
+    default="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz",
+)
+parser.add_argument(
+    "--model_hash",
+    help="Hash of the model archive",
+    type=str,
+    required=False,
+    default="a1dfbce2594f927b9112f23a0a1739e0",
 )
 
 args = parser.parse_args()
@@ -70,6 +84,8 @@ base_json = """
                 "scripts/predict.py",
                 "--image_uri={output_path}/preprocessed.npz.gz",
                 "--benchmark_output_uri={output_path}/prediction_benchmark.json",
+                "--model_path={model_path}",
+                "--model_hash={model_hash}",
                 "--output_uri={output_path}/raw_predictions.npz.gz"
               ]
             }}
@@ -162,6 +178,8 @@ base_json = """
 
 job_json_str = base_json.format(
     bigquery_benchmarking_table=bigquery_benchmarking_table,
+    model_path=args.model_path,
+    model_hash=args.model_hash,
     output_path=output_path,
     input_channels_path=input_channels_path,
     container_image=CONTAINER_IMAGE,

--- a/deepcell_imaging/benchmark_utils.py
+++ b/deepcell_imaging/benchmark_utils.py
@@ -80,7 +80,7 @@ def get_gpu_info():
         raise "Dunno how to handle multiple gpu types"
 
 
-def get_peak_memory():
+def get_peak_memory_gb():
     # The getrusage call returns different units on mac & linux.
     # Get the OS type from the platform library,
     # then set the memory unit factor accordingly.

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -7,8 +7,11 @@ tmp_postprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeli
 input_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/input.png"
 predictions_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/predictions.png"
 
+model_path="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz"
+model_hash="a1dfbce2594f927b9112f23a0a1739e0"
+
 python scripts/preprocess.py --image_uri $1 --output_uri $tmp_preprocess_output
-python scripts/predict.py --image_uri $tmp_preprocess_output --output_uri $tmp_predict_output
+python scripts/predict.py --image_uri $tmp_preprocess_output --model_path $model_path --model_hash $model_hash --output_uri $tmp_predict_output
 python scripts/postprocess.py --raw_predictions_uri $tmp_predict_output --output_uri $tmp_postprocess_output --input_rows 512 --input_cols 512
 python scripts/visualize.py --image_uri $1 --predictions_uri $tmp_postprocess_output --visualized_input_uri $input_png_uri --visualized_predictions_uri $predictions_png_uri
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -132,7 +132,7 @@ def main():
             "postprocessing_gpu_type": gpu_info[0],
             "postprocessing_num_gpus": gpu_info[1],
             "postprocessing_success": success,
-            "postprocessing_peak_memory_gb": benchmark_utils.get_peak_memory(),
+            "postprocessing_peak_memory_gb": benchmark_utils.get_peak_memory_gb(),
             "postprocessing_is_preemptible": benchmark_utils.get_gce_is_preemptible(),
             "postprocessing_input_load_time_s": raw_predictions_load_time_s,
             "postprocessing_time_s": postprocessing_time_s,

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -148,7 +148,7 @@ def main():
             "prediction_gpu_type": gpu_info[0],
             "prediction_num_gpus": gpu_info[1],
             "prediction_success": success,
-            "prediction_peak_memory_gb": benchmark_utils.get_peak_memory(),
+            "prediction_peak_memory_gb": benchmark_utils.get_peak_memory_gb(),
             "prediction_is_preemptible": benchmark_utils.get_gce_is_preemptible(),
             "prediction_model_load_time_s": model_load_time_s,
             "prediction_input_load_time_s": input_load_time_s,

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -51,6 +51,18 @@ def main():
         required=True,
     )
     parser.add_argument(
+        "--model_path",
+        help="Path to the model archive",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--model_hash",
+        help="The hash of the model archive",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
         "--benchmark_output_uri",
         help="Where to write preprocessing benchmarking data.",
         type=str,
@@ -64,11 +76,10 @@ def main():
     output_uri = args.output_uri
     benchmark_output_uri = args.benchmark_output_uri
 
-    # Hard-code remote path & hash based on model_id
-    # THIS IS IN US-CENTRAL1
+    # THE DEFAULT MODEL PATH IS IN US-CENTRAL1
     # If you are running outside us-central1 you should make a copy to avoid egress.
-    model_remote_path = "gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz"
-    model_hash = "a1dfbce2594f927b9112f23a0a1739e0"
+    model_remote_path = args.model_path
+    model_hash = args.model_hash
 
     print("Loading model")
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -119,7 +119,7 @@ def main():
         benchmark_time = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
 
         timing_info = {
-            "input_file_id": image_uri,
+            "input_file_id": filename,
             "numpy_size_mb": round(input_channels.nbytes / 1e6, 2),
             "pixels_m": input_channels.shape[0] * input_channels.shape[1],
             "benchmark_datetime_utc": benchmark_time,

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -127,7 +127,7 @@ def main():
             "preprocessing_gpu_type": gpu_info[0],
             "preprocessing_num_gpus": gpu_info[1],
             "preprocessing_success": success,
-            "preprocessing_peak_memory_gb": benchmark_utils.get_peak_memory(),
+            "preprocessing_peak_memory_gb": benchmark_utils.get_peak_memory_gb(),
             "preprocessing_is_preemptible": benchmark_utils.get_gce_is_preemptible(),
             "preprocessing_input_load_time_s": input_load_time_s,
             "preprocessing_time_s": preprocessing_time_s,


### PR DESCRIPTION
We need to be able to specify the model path & hash, to customize where to pull the model from. This adds those to the multistep job wrapper, as well as to the individual predict.py step.

Also, fixes a bug in reporting the input file id.

Paired with @WeihaoGe1009 