### PR TITLE
Output tiffs as int32 in benchmark + multistep

### DIFF
--- a/batch/run-multistep-job.py
+++ b/batch/run-multistep-job.py
@@ -100,7 +100,8 @@ base_json = """
                 "--input_rows={input_image_rows}",
                 "--input_cols={input_image_cols}",
                 "--benchmark_output_uri={output_path}/postprocess_benchmark.json",
-                "--output_uri={output_path}/predictions.npz.gz"
+                "--output_uri={output_path}/predictions.npz.gz",
+                "--tiff_output_uri={output_path}/predictions.tiff"
               ]
             }}
           }},

--- a/benchmarking/deepcell-e2e/benchmark.py
+++ b/benchmarking/deepcell-e2e/benchmark.py
@@ -231,17 +231,19 @@ def main():
         if output_tiff:
             import tifffile
 
+            segments_int32 = segmentation_predictions.astype(np.int32)
+
             # smart_open doesn't support seeking on GCP, which tifffile uses.
             if output_path.startswith("gs://"):
                 with gs_fastcopy.write(
                     "%s/predictions.tiff" % output_path
                 ) as predictions_tiff_file:
-                    tifffile.imwrite(predictions_tiff_file, segmentation_predictions)
+                    tifffile.imwrite(predictions_tiff_file, segments_int32)
             else:
                 with smart_open.open(
                     "%s/predictions.tiff" % output_path, "wb"
                 ) as predictions_tiff_file:
-                    tifffile.imwrite(predictions_tiff_file, segmentation_predictions)
+                    tifffile.imwrite(predictions_tiff_file, segments_int32)
 
     if visualize_input or visualize_predictions:
         from deepcell.utils.plot_utils import create_rgb_image

--- a/deepcell_imaging/mesmer_app.py
+++ b/deepcell_imaging/mesmer_app.py
@@ -184,7 +184,8 @@ def postprocess(
     )
 
     # Resize label_image back to original resolution if necessary
-    return _resize_output(label_image, input_shape)
+    # But, remove the 1st dimension: batch num.
+    return _resize_output(label_image, input_shape)[0]
 
 
 # pre- and post-processing functions

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -3,6 +3,7 @@
 tmp_preprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/preprocessed.npz.gz"
 tmp_predict_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/raw_predictions.npz.gz"
 tmp_postprocess_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/postprocessed.npz.gz"
+tmp_tiff_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/predictions.tiff"
 
 input_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/input.png"
 predictions_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/predictions.png"
@@ -12,7 +13,7 @@ model_hash="a1dfbce2594f927b9112f23a0a1739e0"
 
 python scripts/preprocess.py --image_uri $1 --output_uri $tmp_preprocess_output
 python scripts/predict.py --image_uri $tmp_preprocess_output --model_path $model_path --model_hash $model_hash --output_uri $tmp_predict_output
-python scripts/postprocess.py --raw_predictions_uri $tmp_predict_output --output_uri $tmp_postprocess_output --input_rows 512 --input_cols 512
+python scripts/postprocess.py --raw_predictions_uri $tmp_predict_output --output_uri $tmp_postprocess_output --input_rows 512 --input_cols 512 --tiff_output_uri $tmp_tiff_output
 python scripts/visualize.py --image_uri $1 --predictions_uri $tmp_postprocess_output --visualized_input_uri $input_png_uri --visualized_predictions_uri $predictions_png_uri
 
 

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -13,6 +13,7 @@ import gs_fastcopy
 import json
 import numpy as np
 import smart_open
+import tifffile
 import timeit
 
 
@@ -70,6 +71,7 @@ def main():
     input_cols = args.input_cols
     compartment = args.compartment
     output_uri = args.output_uri
+    tiff_output_uri = args.tiff_output_uri
     benchmark_output_uri = args.benchmark_output_uri
 
     print("Loading raw predictions")
@@ -108,15 +110,23 @@ def main():
     )
 
     if success:
-        print("Saving postprocessed output to %s" % output_uri)
+        print("Saving postprocessed npz output to %s" % output_uri)
         t = timeit.default_timer()
         with gs_fastcopy.write(output_uri) as output_writer:
             np.savez(output_writer, image=segmentation)
 
-        # TODO (#253): save tiff output.
-
         output_time_s = timeit.default_timer() - t
         print("Saved output in %s s" % round(output_time_s, 2))
+
+        if tiff_output_uri:
+            print("Saving postprocessed TIFF output to %s" % tiff_output_uri)
+            t = timeit.default_timer()
+            segments_int32 = segmentation.astype(np.int32)
+            with gs_fastcopy.write(tiff_output_uri) as output_writer:
+                tifffile.imwrite(output_writer, segments_int32)
+
+            tiff_output_time_s = timeit.default_timer() - t
+            print("Saved tiff output in %s s" % round(tiff_output_time_s, 2))
     else:
         print("Not saving failed postprocessing output.")
         output_time_s = 0.0

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -108,7 +108,7 @@ def main():
     t = timeit.default_timer()
     overlay_data = make_outline_overlay(
         rgb_data=input_rgb[np.newaxis, ...],
-        predictions=predictions,
+        predictions=predictions[np.newaxis, ...],
     )[0]
 
     # The rgb values are 0..1, so normalize to 0..255


### PR DESCRIPTION
This includes an API change: we now return the postprocessed data without the batch dimension. This normalizes it across the app (where we work on 1 image at a time).

Also add a tiff output to multi-step (todo: parameterize filename).

Paired with @WeihaoGe1009 @bnovotny 

Related to #253 (but not quite done yet: need to customize the tiff output name)