### PR TITLE
Use keras format

### DIFF
--- a/batch/run-multistep-job.py
+++ b/batch/run-multistep-job.py
@@ -28,14 +28,14 @@ parser.add_argument(
     help="Path to the model archive",
     type=str,
     required=False,
-    default="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz",
+    default="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation-resaved-20240710.keras",
 )
 parser.add_argument(
     "--model_hash",
     help="Hash of the model archive",
     type=str,
     required=False,
-    default="a1dfbce2594f927b9112f23a0a1739e0",
+    default="56b0f246081fe6b730ca74eab8a37d60",
 )
 
 args = parser.parse_args()

--- a/deepcell_imaging/mesmer_app.py
+++ b/deepcell_imaging/mesmer_app.py
@@ -1,46 +1,23 @@
-"""Mesmer application in pieces"""
+"""
+The Mesmer application, in pieces.
 
-from pathlib import Path
+This was extracted from the DeepCell Mesmer Application, and modified to
+remove the stateful class object. Instead, each function is a standalone
+function that can be called independently.
+"""
 
 import logging
-import numpy as np
-import os
-import sys
 import timeit
 
+import numpy as np
 from deepcell_toolbox.deep_watershed import deep_watershed
-from deepcell_toolbox.processing import percentile_threshold
 from deepcell_toolbox.processing import histogram_normalization
+from deepcell_toolbox.processing import percentile_threshold
 from deepcell_toolbox.utils import resize, tile_image, untile_image
-
-import importlib
-
-file_path = "./deepcell_imaging/__init__.py"
-module_name = "deepcell_imaging"
-spec = importlib.util.spec_from_file_location(module_name, file_path)
-module = importlib.util.module_from_spec(spec)
-sys.modules[module_name] = module
-spec.loader.exec_module(module)
-
-from deepcell_imaging import cached_open
 
 MODEL_REMOTE_PATH = "gs://davids-genomics-data-public/cellular-segmentation/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz"
 
-MODEL_KEY = "models/MultiplexSegmentation-9.tar.gz"
-MODEL_NAME = "MultiplexSegmentation"
-MODEL_HASH = "a1dfbce2594f927b9112f23a0a1739e0"
-
 MESMER_MODEL_MPP = 0.5
-
-downloaded_file_path = cached_open.get_file(
-    "MultiplexSegmentation.tgz",
-    MODEL_REMOTE_PATH,
-    file_hash=MODEL_HASH,
-    extract=True,
-    cache_subdir="models",
-)
-# Remove the .tgz extension to get the model directory path
-model_path = os.path.splitext(downloaded_file_path)[0]
 
 
 def validate_image(model_input_shape, image):

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -8,8 +8,13 @@ tmp_tiff_output="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/pred
 input_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/input.png"
 predictions_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/predictions.png"
 
-model_path="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz"
-model_hash="a1dfbce2594f927b9112f23a0a1739e0"
+# Classic model (SavedModel format)
+# model_path="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz"
+# model_hash="a1dfbce2594f927b9112f23a0a1739e0"
+
+# New model (Keras format)
+model_path="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation-resaved-20240710.keras"
+model_hash="56b0f246081fe6b730ca74eab8a37d60"
 
 python scripts/preprocess.py --image_uri $1 --output_uri $tmp_preprocess_output
 python scripts/predict.py --image_uri $tmp_preprocess_output --model_path $model_path --model_hash $model_hash --output_uri $tmp_predict_output


### PR DESCRIPTION
The post [TensorFlow Performance: Loading Models](https://towardsdatascience.com/tensorflow-performance-loading-models-fb2d0dc340a3) revealed just how much the model format affects its load time. This graph is the punchline:

![Chart of load times for SavedModel vs HDF5 showing a drop from ~10s to ~2s](https://github.com/dchaley/deepcell-imaging/assets/352005/757a7c47-d066-4535-9af2-ead368906ccd)

We loaded the SavedModel format and simply resaved it as `.keras`. To reload it, we needed to reference the DeepCell layer type `Location2D` in the model loader.

The results are astonishing! From local benchmarking:

```
Before:

Loaded model in 12.3 s
Ran prediction in 1.25 s; success: True
After:

Loaded model in 0.84 s
Ran prediction in 1.19 s; success: True
```

A reduction of ~11.5s, or ~90%. 🎉 


This PR also cleans up some model fetching we were doing before the mesmer-in-pieces app became a proper module. Oops 🙈   Sorry @bnovotny 


WIP for: #262 
Open work: test & get load times on cloud