### PR TITLE
Use renamed h5 not .keras (it's actually hdf5)

### DIFF
--- a/batch/run-multistep-job.py
+++ b/batch/run-multistep-job.py
@@ -28,7 +28,7 @@ parser.add_argument(
     help="Path to the model archive",
     type=str,
     required=False,
-    default="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation-resaved-20240710.keras",
+    default="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation-resaved-20240710.h5",
 )
 parser.add_argument(
     "--model_hash",

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -13,7 +13,7 @@ predictions_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/
 # model_hash="a1dfbce2594f927b9112f23a0a1739e0"
 
 # New model (Keras format)
-model_path="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation-resaved-20240710.keras"
+model_path="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation-resaved-20240710.h5"
 model_hash="56b0f246081fe6b730ca74eab8a37d60"
 
 python scripts/preprocess.py --image_uri $1 --output_uri $tmp_preprocess_output


### PR DESCRIPTION
The .keras format didn't come out until 2.12 (maybe later). So, it was implicitly saving as HDF5. Whoops.

I renamed the file on storage, this follows up to adjust the default.

Follow up to #276 