### PR TITLE
Move GCP JSON formatter to root & remove other handlers

### DIFF
--- a/deepcell_imaging/gcp_logging.py
+++ b/deepcell_imaging/gcp_logging.py
@@ -23,3 +23,17 @@ def add_gcp_logging_handler(logger: logging.Logger):
     formatter = GCPFormatter()
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
+
+def initialize_gcp_logging():
+    """
+    Initialize logging for GCP.
+
+    Removes any handlers on the root logger, and
+    adds a new handler that formats logs as JSON.
+    """
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logger.handlers = []
+    add_gcp_logging_handler(logger)
+    return logger

--- a/scripts/gather-benchmark.py
+++ b/scripts/gather-benchmark.py
@@ -24,9 +24,8 @@ from deepcell_imaging import benchmark_utils, gcp_logging
 def main():
     parser = argparse.ArgumentParser("preprocess")
 
-    logger = logging.getLogger(deepcell_imaging.__name__)
-    logger.setLevel(logging.INFO)
-    deepcell_imaging.gcp_logging.add_gcp_logging_handler(logger)
+    deepcell_imaging.gcp_logging.initialize_gcp_logging()
+    logger = logging.getLogger(__name__)
 
     parser.add_argument(
         "--preprocess_benchmarking_uri",

--- a/scripts/postprocess.py
+++ b/scripts/postprocess.py
@@ -22,9 +22,8 @@ import timeit
 def main():
     parser = argparse.ArgumentParser("postprocess")
 
-    logger = logging.getLogger(deepcell_imaging.__name__)
-    logger.setLevel(logging.INFO)
-    deepcell_imaging.gcp_logging.add_gcp_logging_handler(logger)
+    deepcell_imaging.gcp_logging.initialize_gcp_logging()
+    logger = logging.getLogger(__name__)
 
     parser.add_argument(
         "--raw_predictions_uri",

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -37,9 +37,8 @@ from deepcell_imaging import (
 def main():
     parser = argparse.ArgumentParser("predict")
 
-    logger = logging.getLogger(deepcell_imaging.__name__)
-    logger.setLevel(logging.INFO)
-    deepcell_imaging.gcp_logging.add_gcp_logging_handler(logger)
+    deepcell_imaging.gcp_logging.initialize_gcp_logging()
+    logger = logging.getLogger(__name__)
 
     parser.add_argument(
         "--image_uri",

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -25,9 +25,8 @@ from deepcell_imaging import gcp_logging, benchmark_utils, mesmer_app
 def main():
     parser = argparse.ArgumentParser("preprocess")
 
-    logger = logging.getLogger(deepcell_imaging.__name__)
-    logger.setLevel(logging.INFO)
-    deepcell_imaging.gcp_logging.add_gcp_logging_handler(logger)
+    deepcell_imaging.gcp_logging.initialize_gcp_logging()
+    logger = logging.getLogger(__name__)
 
     parser.add_argument(
         "--image_uri",

--- a/scripts/visualize.py
+++ b/scripts/visualize.py
@@ -24,9 +24,8 @@ from deepcell_imaging import gcp_logging
 def main():
     parser = argparse.ArgumentParser("visualize")
 
-    logger = logging.getLogger(deepcell_imaging.__name__)
-    logger.setLevel(logging.INFO)
-    deepcell_imaging.gcp_logging.add_gcp_logging_handler(logger)
+    deepcell_imaging.gcp_logging.initialize_gcp_logging()
+    logger = logging.getLogger(__name__)
 
     parser.add_argument(
         "--image_uri",


### PR DESCRIPTION
We saw duplicate log entries after we added the GCP handler: https://github.com/dchaley/deepcell-imaging/issues/279

We saw this once locally, but it went away; then it came back on cloud. This should "just fix" it.

This PR removes any default handlers from the root logger, and moves the GCP JSON formatter to the root as well (so that ALL loggers use it, not just our own).

Paired with @WeihaoGe1009 

Fixes #279.