### PR TITLE
Pass compartment from runner to job json

### DIFF
--- a/batch/run-multistep-job.py
+++ b/batch/run-multistep-job.py
@@ -19,6 +19,13 @@ parser.add_argument(
     required=True,
 )
 parser.add_argument(
+    "--compartment",
+    help="Compartment to segment. One of 'whole-cell' (default) or 'nuclear' or 'both'.",
+    type=str,
+    required=False,
+    default="whole-cell",
+)
+parser.add_argument(
     "--bigquery_benchmarking_table",
     help="BigQuery table to write benchmarking results to (empty for none)",
     type=str,
@@ -78,6 +85,7 @@ job_json = make_job_json(
     model_hash=args.model_hash,
     bigquery_benchmarking_table=bigquery_benchmarking_table,
     input_channels_path=input_channels_path,
+    compartment=args.compartment,
     working_directory=output_path,
     tiff_output_uri="{}/{}.tiff".format(output_path, input_file_stem),
     input_image_rows=input_image_shape[0],

--- a/batch/run-qupath-job.py
+++ b/batch/run-qupath-job.py
@@ -91,6 +91,7 @@ job_json = make_job_json(
     model_hash=args.model_hash,
     bigquery_benchmarking_table=bigquery_benchmarking_table,
     input_channels_path=input_channels_path,
+    compartment=compartment,
     working_directory=job_intermediate_path,
     tiff_output_uri=tiff_output_uri,
     input_image_rows=input_image_shape[0],

--- a/deepcell_imaging/gcp_batch_jobs.py
+++ b/deepcell_imaging/gcp_batch_jobs.py
@@ -49,6 +49,7 @@ BASE_MULTISTEP_TEMPLATE = """
                                 "--raw_predictions_uri={job_intermediate_path}/raw_predictions.npz.gz",
                                 "--input_rows={input_image_rows}",
                                 "--input_cols={input_image_cols}",
+                                "--compartment={compartment}",
                                 "--benchmark_output_uri={job_intermediate_path}/postprocess_benchmark.json",
                                 "--output_uri={job_intermediate_path}/predictions.npz.gz",
                                 "--tiff_output_uri={tiff_output_uri}"
@@ -135,6 +136,7 @@ def make_job_json(
     model_hash: str,
     bigquery_benchmarking_table: str,
     input_channels_path: str,
+    compartment: str,
     working_directory: str,
     tiff_output_uri: str,
     input_image_rows: int,
@@ -146,6 +148,7 @@ def make_job_json(
         model_path=model_path,
         model_hash=model_hash,
         input_channels_path=input_channels_path,
+        compartment=compartment,
         job_intermediate_path=working_directory,
         tiff_output_uri=tiff_output_uri,
         input_image_rows=input_image_rows,


### PR DESCRIPTION
We used to take the parameter but ... do nothing with it. 🤦🏻  This now passes it through properly.

Paired with @WeihaoGe1009 

Fixes #285 