### PR TITLE
Accept indexed task args

### DIFF
--- a/batch/run-multistep-job.py
+++ b/batch/run-multistep-job.py
@@ -77,6 +77,8 @@ input_file_stem = pathlib.Path(parsed_input_path.path).stem
 if args.configuration:
     with open(args.configuration, "r") as f:
         config = json.load(f)
+else:
+    config = {}
 
 job_json = make_job_json(
     region=REGION,

--- a/batch/run-qupath-job.py
+++ b/batch/run-qupath-job.py
@@ -83,6 +83,8 @@ input_image_shape = input_file_contents[0][1]
 if args.configuration:
     with open(args.configuration, "r") as f:
         config = json.load(f)
+else:
+    config = {}
 
 job_json = make_job_json(
     region=REGION,

--- a/deepcell_imaging/gcp_batch_jobs.py
+++ b/deepcell_imaging/gcp_batch_jobs.py
@@ -3,6 +3,9 @@ This module contains functions for creating and submitting batch jobs to GCP.
 """
 
 import json
+import os
+
+import smart_open
 
 # A lot of stuff gets hardcoded in this json.
 # See the README for limitations.
@@ -163,3 +166,13 @@ def make_job_json(
         job_json.update(config)
 
     return job_json
+
+
+def get_batch_indexed_task(tasks_spec_uri, args_cls):
+    with smart_open.open(tasks_spec_uri, "r") as tasks_spec_file:
+        tasks_spec = json.load(tasks_spec_file)
+
+    task_index = int(os.environ["BATCH_TASK_INDEX"])
+    task = tasks_spec[task_index]
+
+    return args_cls(**task)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ imagecodecs
 JSON-log-formatter
 numpy
 protobuf==3.20.3
+pydantic
 pytest
 requests
 smart_open[gcs]

--- a/scripts/gather-benchmark.py
+++ b/scripts/gather-benchmark.py
@@ -12,13 +12,23 @@ import io
 import json
 import logging
 import timeit
+from typing import Optional
 
 import smart_open
 from google.cloud import bigquery
+from pydantic import BaseModel
 from tenacity import retry, retry_if_exception_message, wait_random_exponential
 
 import deepcell_imaging
 from deepcell_imaging import benchmark_utils, gcp_logging
+from deepcell_imaging.gcp_batch_jobs import get_batch_indexed_task
+
+
+class GatherBenchmarkArgs(BaseModel):
+    preprocess_benchmarking_uri: str
+    prediction_benchmarking_uri: str
+    postprocess_benchmarking_uri: str
+    bigquery_benchmarking_table: Optional[str] = None
 
 
 def main():
@@ -28,31 +38,48 @@ def main():
     logger = logging.getLogger(__name__)
 
     parser.add_argument(
-        "--preprocess_benchmarking_uri",
-        help="URI to benchmarking data for the preprocessing step.",
+        "--tasks_spec_uri",
+        help="URI to a JSON file containing a list of task parameters",
         type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "--prediction_benchmarking_uri",
-        help="URI to benchmarking data for the prediction step.",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "--postprocess_benchmarking_uri",
-        help="URI to benchmarking data for the postprocessing step.",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "--bigquery_benchmarking_table",
-        help="The fully qualified name (project.dataset.table) of the BigQuery table to write benchmarking data to.",
-        type=str,
-        required=True,
+        required=False,
     )
 
-    args = parser.parse_args()
+    parsed_args, args_remainder = parser.parse_known_args()
+
+    if parsed_args.tasks_spec_uri:
+        if len(args_remainder) > 0:
+            raise ValueError("Either pass --tasks_spec_uri alone, or not at all")
+
+        args = get_batch_indexed_task(parsed_args.tasks_spec_uri, GatherBenchmarkArgs)
+    else:
+        parser.add_argument(
+            "--preprocess_benchmarking_uri",
+            help="URI to benchmarking data for the preprocessing step.",
+            type=str,
+            required=True,
+        )
+        parser.add_argument(
+            "--prediction_benchmarking_uri",
+            help="URI to benchmarking data for the prediction step.",
+            type=str,
+            required=True,
+        )
+        parser.add_argument(
+            "--postprocess_benchmarking_uri",
+            help="URI to benchmarking data for the postprocessing step.",
+            type=str,
+            required=True,
+        )
+        parser.add_argument(
+            "--bigquery_benchmarking_table",
+            help="The fully qualified name (project.dataset.table) of the BigQuery table to write benchmarking data to.",
+            type=str,
+            required=True,
+        )
+
+        parsed_args = parser.parse_args(args_remainder)
+        kwargs = {k: v for k, v in vars(parsed_args).items() if v is not None}
+        args = GatherBenchmarkArgs(**kwargs)
 
     preprocess_benchmarking_uri = args.preprocess_benchmarking_uri
     prediction_benchmarking_uri = args.prediction_benchmarking_uri

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -12,7 +12,7 @@ predictions_png_uri="gs://deepcell-batch-jobs_us-central1/job-runs/tmp-pipeline/
 # model_path="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation.tar.gz"
 # model_hash="a1dfbce2594f927b9112f23a0a1739e0"
 
-# New model (Keras format)
+# New model (HDF5 format)
 model_path="gs://genomics-data-public-central1/cellular-segmentation/vanvalenlab/deep-cell/vanvalenlab-tf-model-multiplex-downloaded-20230706/MultiplexSegmentation-resaved-20240710.h5"
 model_hash="56b0f246081fe6b730ca74eab8a37d60"
 

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -85,8 +85,6 @@ def main():
     output_uri = args.output_uri
     benchmark_output_uri = args.benchmark_output_uri
 
-    # THE DEFAULT MODEL PATH IS IN US-CENTRAL1
-    # If you are running outside us-central1 you should make a copy to avoid egress.
     model_remote_path = args.model_path
     model_hash = args.model_hash
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -13,13 +13,24 @@ import logging
 import timeit
 import urllib
 from datetime import datetime, timezone
+from typing import Optional
 
 import gs_fastcopy
 import numpy as np
 import smart_open
+from pydantic import BaseModel
 
 import deepcell_imaging
 from deepcell_imaging import gcp_logging, benchmark_utils, mesmer_app
+from deepcell_imaging.gcp_batch_jobs import get_batch_indexed_task
+
+
+class PreprocessArgs(BaseModel):
+    image_uri: str
+    image_array_name: str = "input_channels"
+    image_mpp: Optional[float] = None
+    output_uri: str
+    benchmark_output_uri: Optional[str] = None
 
 
 def main():
@@ -29,38 +40,54 @@ def main():
     logger = logging.getLogger(__name__)
 
     parser.add_argument(
-        "--image_uri",
-        help="URI to input image npz file, containing an array named 'input_channels' by default (see --image-array-name)",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "--image_array_name",
-        help="Name of array in input image npz file, default input_channels",
-        type=str,
-        required=False,
-        default="input_channels",
-    )
-    parser.add_argument(
-        "--image_mpp",
-        help="Optional float representing microns per pixel of input image. Leave blank to use model's mpp",
-        type=float,
-        required=False,
-    )
-    parser.add_argument(
-        "--output_uri",
-        help="Where to write preprocessed input npz file containing an array named 'image'",
-        type=str,
-        required=True,
-    )
-    parser.add_argument(
-        "--benchmark_output_uri",
-        help="Where to write preprocessing benchmarking data.",
+        "--tasks_spec_uri",
+        help="URI to a JSON file containing a list of task parameters",
         type=str,
         required=False,
     )
 
-    args = parser.parse_args()
+    parsed_args, args_remainder = parser.parse_known_args()
+
+    if parsed_args.tasks_spec_uri:
+        if len(args_remainder) > 0:
+            raise ValueError("Either pass --tasks_spec_uri alone, or not at all")
+
+        args = get_batch_indexed_task(parsed_args.tasks_spec_uri, PreprocessArgs)
+    else:
+        parser.add_argument(
+            "--image_uri",
+            help="URI to input image npz file, containing an array named 'input_channels' by default (see --image-array-name)",
+            type=str,
+            required=True,
+        )
+        parser.add_argument(
+            "--image_array_name",
+            help="Name of array in input image npz file, default input_channels",
+            type=str,
+            required=False,
+        )
+        parser.add_argument(
+            "--image_mpp",
+            help="Optional float representing microns per pixel of input image. Leave blank to use model's mpp",
+            type=float,
+            required=False,
+        )
+        parser.add_argument(
+            "--output_uri",
+            help="Where to write preprocessed input npz file containing an array named 'image'",
+            type=str,
+            required=True,
+        )
+        parser.add_argument(
+            "--benchmark_output_uri",
+            help="Where to write preprocessing benchmarking data.",
+            type=str,
+            required=False,
+        )
+
+        parsed_args = parser.parse_args(args_remainder)
+        kwargs = {k: v for k, v in vars(parsed_args).items() if v is not None}
+        args = PreprocessArgs(**kwargs)
 
     image_uri = args.image_uri
     image_array_name = args.image_array_name


### PR DESCRIPTION
To support running on multiple inputs in one job, we need the task runners to understand $BATCH_TASK_INDEX: they use this to determine which of a list of inputs they're operating upon.

The bulk of the work is updating how the scripts take their command-line arguments: either a file, or, individual arguments as usual.

This introduces pydantic as a way to define the script parameters aka API. The idea is to reduce duplicated data like which parameters are required or what their defaults are. (Some more work needed here like generating the arguments from the type def, and moving the help text into the type too.)

This adds a helper to fetch the task list.

Relates to #292

Most of this paired with @WeihaoGe1009 

**REVIEW NOTE**: consider ignoring whitespace to see that the args are (mostly) just indented.