### PR TITLE
Add script to enqueue QuPath job

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update -y && \
-    apt-get install -y git google-cloud-sdk google-cloud-cli pigz && \
+    apt-get install -y --no-install-recommends git google-cloud-sdk google-cloud-cli pigz && \
     rm -rf /var/lib/apt/lists/* && \
     /usr/bin/python3 -m pip install --no-cache-dir --upgrade pip && \
     gcloud config set storage/parallel_composite_upload_enabled True

--- a/scripts/launch-qupath-measurement.py
+++ b/scripts/launch-qupath-measurement.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import json
+import os
+import subprocess
+import tempfile
+import uuid
+
+import deepcell_imaging.gcp_logging
+import logging
+
+from deepcell_imaging.gcp_batch_jobs.qupath_measurements import (
+    make_qupath_measurements_job_json,
+)
+from deepcell_imaging.gcp_batch_jobs.types import QupathMeasurementArgs
+from deepcell_imaging.utils.cmdline import get_task_arguments
+
+CONTAINER_IMAGE = "us-central1-docker.pkg.dev/deepcell-on-batch/deepcell-benchmarking-us-central1/qupath-project-initializer:latest"
+REGION = "us-central1"
+
+
+def main():
+    deepcell_imaging.gcp_logging.initialize_gcp_logging()
+    logger = logging.getLogger(__name__)
+
+    try:
+        task_index = int(os.environ["BATCH_TASK_INDEX"])
+    except KeyError:
+        logger.info("Not running on batch? Assuming task index 0.")
+        task_index = 0
+
+    if task_index != 0:
+        logger.info(f"Skipping task {task_index}; we only run the first task.")
+        return
+
+    args = get_task_arguments("launch_qupath_measurement", QupathMeasurementArgs)
+
+    job_json = make_qupath_measurements_job_json(
+        region=REGION,
+        container_image=CONTAINER_IMAGE,
+        images_path=args.images_path,
+        segmasks_path=args.segmasks_path,
+        project_path=args.project_path,
+        reports_path=args.reports_path,
+        image_filter=args.image_filter,
+    )
+
+    job_json_file = tempfile.NamedTemporaryFile()
+    with open(job_json_file.name, "w") as f:
+        json.dump(job_json, f)
+
+    # The batch job id must be unique, and can only contain lowercase letters,
+    # numbers, and hyphens. It must also be 63 characters or fewer.
+    # We're doing 62 to be safe.
+    #
+    # Regex: ^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$
+    batch_job_id = "qupath-{}".format(str(uuid.uuid4()))
+    batch_job_id = batch_job_id[0:62].lower()
+
+    cmd = "gcloud batch jobs submit {job_id} --location {location} --config {job_filename}".format(
+        job_id=batch_job_id, location=REGION, job_filename=job_json_file.name
+    )
+    subprocess.run(cmd, shell=True)
+
+    logger.info("Job submitted with ID: {}".format(batch_job_id))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deepcell_imaging/gcp_batch_jobs/multitask.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/multitask.py
@@ -84,6 +84,7 @@ BASE_MULTITASK_TEMPLATE = """
                 ]
             }},
             "taskCount": {task_count},
+            "taskCountPerNode": 1,
             "parallelism": 1
         }}
     ],

--- a/src/deepcell_imaging/gcp_batch_jobs/qupath_measurements.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/qupath_measurements.py
@@ -1,0 +1,106 @@
+import json
+from typing import Optional
+
+import smart_open
+from pydantic import BaseModel
+
+from deepcell_imaging.gcp_batch_jobs.types import (
+    PreprocessArgs,
+    PredictArgs,
+    PostprocessArgs,
+    GatherBenchmarkArgs,
+    VisualizeArgs,
+)
+
+# Note: Need to escape the curly braces in the JSON template
+BASE_QUPATH_MEASUREMENTS_TEMPLATE = """
+{{
+    "taskGroups": [
+        {{
+            "taskSpec": {{
+                "runnables": [
+                    {{
+                        "container": {{
+                            "imageUri": "{container_image}",
+                            "entrypoint": "java",
+                            "commands": [
+                                "-jar",
+                                "/app/qupath-project-initializer-1.0-SNAPSHOT-all.jar",
+                                "--mode=explicit",
+                                "--images-path={images_path}",
+                                "--segmasks-path={segmasks_path}",
+                                "--project-path={project_path}",
+                                "--reports-path={reports_path}",
+                                "--image-filter={image_filter}"
+                            ]
+                        }}
+                    }}
+                ],
+                "computeResource": {{
+                    "memoryMib": 26000
+                }},
+                "maxRetryCount": 3,
+                "lifecyclePolicies": [
+                    {{
+                        "action": "RETRY_TASK",
+                        "actionCondition": {{
+                            "exitCodes": [50001]
+                        }}
+                    }}
+                ]
+            }},
+            "taskCount": 1,
+            "parallelism": 1,
+            "taskCountPerNode": 1
+        }}
+    ],
+    "allocationPolicy": {{
+        "instances": [
+            {{
+                "policy": {{
+                    "machineType": "n1-standard-8",
+                    "provisioningModel": "SPOT"
+                }}
+            }}
+        ],
+        "location": {{
+            "allowedLocations": [
+                "regions/{region}"
+            ]
+        }}
+    }},
+
+    "logsPolicy": {{
+        "destination": "CLOUD_LOGGING"
+    }}
+}}
+"""
+
+
+def make_qupath_measurements_job_json(
+    region: str,
+    container_image: str,
+    images_path: str,
+    segmasks_path: str,
+    project_path: str,
+    reports_path: str,
+    image_filter: str,
+    config: dict = None,
+) -> dict:
+    json_str = BASE_QUPATH_MEASUREMENTS_TEMPLATE.format(
+        container_image=container_image,
+        region=region,
+        images_path=images_path,
+        segmasks_path=segmasks_path,
+        project_path=project_path,
+        reports_path=reports_path,
+        image_filter=image_filter,
+    )
+
+    print(json_str)
+    job_json = json.loads(json_str)
+
+    if config:
+        job_json.update(config)
+
+    return job_json

--- a/src/deepcell_imaging/gcp_batch_jobs/types.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/types.py
@@ -138,3 +138,27 @@ class GatherBenchmarkArgs(BaseModel):
         title="BigQuery benchmarking table",
         description="The fully qualified name (project.dataset.table) of the BigQuery table to write benchmarking data to. Default/blank: don't write to BigQuery.",
     )
+
+
+class QupathMeasurementArgs(BaseModel):
+    images_path: str = Field(
+        title="Images Path",
+        description="Path to the directory containing the images for QuPath.",
+    )
+    segmasks_path: str = Field(
+        title="Segmentation Masks Path",
+        description="Path to the directory containing the segmentation masks for QuPath.",
+    )
+    project_path: str = Field(
+        title="Project Path",
+        description="Path to the QuPath project root.",
+    )
+    reports_path: str = Field(
+        title="Reports Path",
+        description="Path to the QuPath reports root.",
+    )
+    image_filter: str = Field(
+        default="",
+        title="Image Filter",
+        description="Filter for which image names to process. Default/blank: no filter.",
+    )


### PR DESCRIPTION
This script enqueues a Batch job to run QuPath measurements. It's intended to be the final step in a pipeline generating

(1) segmentation from DeepCell and
(2) quantitative measurement reports from QuPath.

Fixes #311

Paired with @WeihaoGe1009 

Example reports output:

<img width="713" alt="Screenshot 2024-08-15 at 2 47 12 PM" src="https://github.com/user-attachments/assets/26bc90d4-cc84-4e53-a91b-a37d69e6a8f2">
