### PR TITLE
Make command line parameter optional

### DIFF
--- a/src/deepcell_imaging/utils/cmdline.py
+++ b/src/deepcell_imaging/utils/cmdline.py
@@ -25,7 +25,7 @@ def get_task_arguments(
         "--env_config_uri",
         help="URI to a JSON file containing environment configuration",
         type=str,
-        required=True,
+        required=False,
     )
 
     env_config = None


### PR DESCRIPTION
Third time is the charm? Some steps don't need the env config: so the argument shouldn't be required.