### PR TITLE
Add segmentation boot disk based on image size

### DIFF
--- a/scripts/segment-and-measure.py
+++ b/scripts/segment-and-measure.py
@@ -152,7 +152,9 @@ def main():
     logger.info("Fetching images")
 
     image_paths = get_blob_filenames(image_root, client=client)
-    image_paths = [x for x in image_paths if x == args.image_filter]
+    image_paths = [
+        x for x in image_paths if (not args.image_filter or x == args.image_filter)
+    ]
 
     logger.info("Finding matching npz files")
 

--- a/src/deepcell_imaging/gcp_batch_jobs/__init__.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/__init__.py
@@ -62,6 +62,17 @@ def apply_cloud_logs_policy(job: dict) -> None:
     job["logsPolicy"] = {"destination": "CLOUD_LOGGING"}
 
 
+def set_boot_disk_size(job: dict, size_mib: int) -> None:
+    """
+    Set the boot disk size for the job definition.
+    """
+    # setdefault is used if the computeResource key does not exist yet
+    compute_resource = job["taskGroups"][0]["taskSpec"].setdefault(
+        "computeResource", {}
+    )
+    compute_resource["bootDiskMib"] = size_mib
+
+
 def submit_job(job: dict, job_id: str, region: str) -> None:
     """
     Submit a job to the Batch service.

--- a/src/deepcell_imaging/gcp_batch_jobs/segment.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/segment.py
@@ -7,6 +7,7 @@ import smart_open
 from deepcell_imaging.gcp_batch_jobs import (
     apply_cloud_logs_policy,
     apply_allocation_policy,
+    set_boot_disk_size,
 )
 from deepcell_imaging.gcp_batch_jobs.types import (
     PreprocessArgs,
@@ -278,6 +279,14 @@ def build_segment_job_tasks(
         gpu_count=1,
     )
     apply_cloud_logs_policy(job)
+
+    # Set boot disk size based on the largest input image.
+    # The largest intermediate file (raw predictions) has 4 float64s per pixel.
+    biggest_pixels = max(
+        [task.input_image_rows * task.input_image_cols for task in tasks]
+    )
+    size_in_bytes = biggest_pixels * 8 * 4
+    set_boot_disk_size(job, size_in_bytes // 1024 // 1024)
 
     if config:
         job.update(config)


### PR DESCRIPTION
The segmentation job uses local storage to download the input image and for intermediate storage. The default (30GB) isn't enough for larger images. This increases the boot disk size based on the input size.

Unfortunately, although we see the added space in the job json, it doesn't seem to be reflected in the GCE instance.

Paired with @WeihaoGe1009 