### PR TITLE
Add BQ benchmarking table ID to environment config

### DIFF
--- a/scripts/segment-and-measure.py
+++ b/scripts/segment-and-measure.py
@@ -186,6 +186,7 @@ def main():
         tasks=image_segmentation_tasks,
         compartment="both",
         working_directory=working_directory,
+        bigquery_benchmarking_table=env_config.bigquery_benchmarking_table,
     )
 
     # Note that we use the SEGMENT container here, not quantify,

--- a/src/deepcell_imaging/gcp_batch_jobs/types.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/types.py
@@ -18,6 +18,11 @@ class EnvironmentConfig(BaseModel):
         title="Quantify Container Image",
         description="The container image to use for the quantify job.",
     )
+    bigquery_benchmarking_table: str = Field(
+        default="",
+        title="BigQuery Benchmarking Table",
+        description="The fully qualified name (project.dataset.table) of the BigQuery table to write benchmarking data to. Default/blank: don't save benchmarking.",
+    )
 
 
 class SegmentationTask(BaseModel):


### PR DESCRIPTION
Add an optional parameter to the environment configuration, specifying where to upload benchmarking data. If blank or unspecified, just don't upload any benchmarking.

Fixes #331 

Paired with @WeihaoGe1009 