### PR TITLE
Add segmentation-only job

### DIFF
--- a/src/deepcell_imaging/utils/cmdline.py
+++ b/src/deepcell_imaging/utils/cmdline.py
@@ -60,3 +60,95 @@ def get_task_arguments(
         parsed_args = parser.parse_args(args_remainder)
         kwargs = {k: v for k, v in vars(parsed_args).items() if v is not None}
         return args_cls(**kwargs), env_config
+
+
+def add_dataset_parameters(parser: argparse.ArgumentParser) -> None:
+    subparsers = parser.add_subparsers(help="Mode of operation", dest="mode")
+
+    workspace_parser = subparsers.add_parser("workspace")
+    workspace_parser.add_argument(
+        "dataset_path",  # positional argument
+        help="Path to the dataset",
+    )
+    workspace_parser.add_argument(
+        "--images_subdir",
+        help="Subdirectory within the dataset containing the images",
+        type=str,
+        default="OMETIFF",
+    )
+    workspace_parser.add_argument(
+        "--npz_subdir",
+        help="Subdirectory within the dataset containing the image files as numpy arrays",
+        type=str,
+        default="NPZ_INTERMEDIATE",
+    )
+    workspace_parser.add_argument(
+        "--segmasks_subdir",
+        help="Subdirectory within the dataset containing the segmentation masks",
+        type=str,
+        default="SEGMASK",
+    )
+    workspace_parser.add_argument(
+        "--project_subdir",
+        help="Subdirectory within the dataset containing the QuPath project",
+        type=str,
+        default="PROJ",
+    )
+    workspace_parser.add_argument(
+        "--reports_subdir",
+        help="Subdirectory within the dataset containing the QuPath reports",
+        type=str,
+        default="REPORTS",
+    )
+
+    paths_parser = subparsers.add_parser("paths")
+    paths_parser.add_argument(
+        "--images_path",
+        help="Path to the images",
+        required=True,
+    )
+    paths_parser.add_argument(
+        "--numpy_path",
+        help="Path to the images as numpy arrays",
+        required=True,
+    )
+    paths_parser.add_argument(
+        "--segmasks_path",
+        help="Path to the segmentation masks",
+        required=True,
+    )
+    paths_parser.add_argument(
+        "--project_path",
+        help="Path to the QuPath project",
+        required=True,
+    )
+    paths_parser.add_argument(
+        "--reports_path",
+        help="Path to the QuPath reports",
+        required=True,
+    )
+
+
+def get_dataset_paths(args) -> dict:
+    if args.mode == "workspace":
+        image_root = f"{args.dataset_path}/{args.images_subdir}"
+        npz_root = f"{args.dataset_path}/{args.npz_subdir}"
+        masks_output_root = f"{args.dataset_path}/{args.segmasks_subdir}"
+        project_root = f"{args.dataset_path}/{args.project_subdir}"
+        reports_root = f"{args.dataset_path}/{args.reports_subdir}"
+    elif args.mode == "paths":
+        image_root = args.images_path
+        npz_root = args.numpy_path
+        masks_output_root = args.segmasks_path
+        project_root = args.project_path
+        reports_root = args.reports_path
+    else:
+        raise ValueError(f"Invalid mode: {args.mode}")
+
+    return {
+        "image_root": image_root,
+        "npz_root": npz_root,
+        "masks_output_root": masks_output_root,
+        "project_root": project_root,
+        "reports_root": reports_root,
+    }


### PR DESCRIPTION
This adds a job to just segment a dataset's images, without enqueuing the QuPath portion. Along the way we extract shared code between the two scripts (segment, and segment-and-measure).

Fixes #327

Paired with @WeihaoGe1009 