### PR TITLE
Set networking & service account in env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ You'll need a JSON file available in a cloud bucket, configuring the application
   "segment_container_image": "$REPOSITORY/benchmarking:batch",
   "quantify_container_image": "$REPOSITORY/qupath-project-initializer:latest",
   "bigquery_benchmarking_table": "$PROJECT.$DATASET.$TABLE",
-  "region": "$REGION"
+  "region": "$REGION",
+  "networking_interface": {
+    "network": "the_network",
+    "subnetwork": "the_subnetwork",
+    "no_external_ip_address": true
+  },
+  "service_account": {
+    "email": "the_service@account.com"
+  }
 }
 ```
 
@@ -32,8 +40,9 @@ You'll need to replace the variables with your environment.
 - You can use the public Docker Hub containers, or copy them to your own artifact repository. 
 - For the benchmarking, you need to create a dataset & table in a GCP project; or you can omit it or set it to blank to skip collecting benchmarks. The table must be created with the schema specified in [this file](benchmarking/bigquery_benchmarking_schema.json).
 - Lastly, specify the GCP region where compute resources will be provisioned. This is not the same as storage buckets, but consider making it the same for efficiency & egress cost reduction.
+- The `networking_interface` and `service_account` sections are optional if you want to use default settings.
 
-For example, using the Docker Hub containers & skipping benchmarking:
+For example, using the Docker Hub containers & skipping benchmarking & default networking + service account:
 
 ```json
 {

--- a/scripts/launch-qupath-measurement.py
+++ b/scripts/launch-qupath-measurement.py
@@ -48,6 +48,8 @@ def main():
         region=region,
         container_image=container_image,
         args=args,
+        networking_interface=env_config.networking_interface,
+        service_account=env_config.service_account,
     )
 
     job_json_file = tempfile.NamedTemporaryFile()

--- a/scripts/segment-and-measure.py
+++ b/scripts/segment-and-measure.py
@@ -115,6 +115,8 @@ def main():
         compartment="both",
         working_directory=working_directory,
         bigquery_benchmarking_table=env_config.bigquery_benchmarking_table,
+        networking_interface=env_config.networking_interface,
+        service_account=env_config.service_account,
     )
 
     # Note that we use the SEGMENT container here, not quantify,

--- a/src/deepcell_imaging/gcp_batch_jobs/__init__.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/__init__.py
@@ -9,6 +9,11 @@ import tempfile
 
 import smart_open
 
+from deepcell_imaging.gcp_batch_jobs.types import (
+    NetworkInterfaceConfig,
+    ServiceAccountConfig,
+)
+
 
 def get_batch_indexed_task(tasks_spec_uri, args_cls):
     with smart_open.open(tasks_spec_uri, "r") as tasks_spec_file:
@@ -98,6 +103,16 @@ def set_task_environment_variable(job: dict, key: str, value: str) -> None:
     env = job["taskGroups"][0]["taskSpec"].setdefault("environment", {})
     env_vars = env.setdefault("variables", {})
     env_vars[key] = value
+
+
+def add_networking_interface(job: dict, networking_interface: NetworkInterfaceConfig):
+    job["allocationPolicy"].setdefault("network", {})["networkInterfaces"] = [
+        networking_interface.model_dump()
+    ]
+
+
+def add_service_account(job: dict, service_account: ServiceAccountConfig):
+    job["allocationPolicy"]["serviceAccount"] = service_account.model_dump()
 
 
 def submit_job(job: dict, job_id: str, region: str) -> None:

--- a/src/deepcell_imaging/gcp_batch_jobs/quantify.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/quantify.py
@@ -6,8 +6,14 @@ from deepcell_imaging.gcp_batch_jobs import (
     add_attached_disk,
     add_task_volume,
     set_task_environment_variable,
+    add_networking_interface,
+    add_service_account,
 )
-from deepcell_imaging.gcp_batch_jobs.types import QuantifyArgs
+from deepcell_imaging.gcp_batch_jobs.types import (
+    QuantifyArgs,
+    ServiceAccountConfig,
+    NetworkInterfaceConfig,
+)
 
 # Note: Need to escape the curly braces in the JSON template
 BASE_QUANTIFY_JOB_TEMPLATE = """
@@ -84,6 +90,8 @@ def make_quantify_job(
     region: str,
     container_image: str,
     args: QuantifyArgs,
+    networking_interface: NetworkInterfaceConfig = None,
+    service_account: ServiceAccountConfig = None,
     config: dict = None,
 ) -> dict:
     json_str = BASE_QUANTIFY_JOB_TEMPLATE.format(
@@ -117,6 +125,12 @@ def make_quantify_job(
     add_attached_disk(job, volume_name, size_in_gb)
     add_task_volume(job, tmp_dir, volume_name)
     set_task_environment_variable(job, "TMPDIR", tmp_dir)
+
+    if networking_interface:
+        add_networking_interface(job, networking_interface)
+
+    if service_account:
+        add_service_account(job, service_account)
 
     if config:
         job.update(config)

--- a/src/deepcell_imaging/gcp_batch_jobs/segment.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/segment.py
@@ -10,6 +10,8 @@ from deepcell_imaging.gcp_batch_jobs import (
     add_attached_disk,
     add_task_volume,
     set_task_environment_variable,
+    add_networking_interface,
+    add_service_account,
 )
 from deepcell_imaging.gcp_batch_jobs.types import (
     PreprocessArgs,
@@ -18,6 +20,8 @@ from deepcell_imaging.gcp_batch_jobs.types import (
     GatherBenchmarkArgs,
     VisualizeArgs,
     SegmentationTask,
+    NetworkInterfaceConfig,
+    ServiceAccountConfig,
 )
 from deepcell_imaging.utils.numpy import npz_headers
 from deepcell_imaging.utils.storage import find_matching_npz
@@ -225,6 +229,8 @@ def build_segment_job_tasks(
     compartment: str,
     working_directory: str,
     bigquery_benchmarking_table: Optional[str] = None,
+    networking_interface: NetworkInterfaceConfig = None,
+    service_account: ServiceAccountConfig = None,
     config: dict = None,
 ) -> dict:
 
@@ -294,6 +300,12 @@ def build_segment_job_tasks(
     add_attached_disk(job, volume_name, size_in_bytes // 1024 // 1024 // 1024)
     add_task_volume(job, tmp_dir, volume_name)
     set_task_environment_variable(job, "TMPDIR", tmp_dir)
+
+    if networking_interface:
+        add_networking_interface(job, networking_interface)
+
+    if service_account:
+        add_service_account(job, service_account)
 
     if config:
         job.update(config)

--- a/src/deepcell_imaging/gcp_batch_jobs/types.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/types.py
@@ -5,6 +5,37 @@ from pydantic import BaseModel, Field, ConfigDict
 DEFAULT_BATCH_SIZE = 16
 
 
+class NetworkInterfaceConfig(BaseModel):
+    network: str = Field(
+        default="",
+        title="Network",
+        description="The network to use for the job.",
+    )
+    subnetwork: str = Field(
+        default="",
+        title="Subnetwork",
+        description="The subnetwork to use for the job.",
+    )
+    no_external_ip_address: bool = Field(
+        default=False,
+        title="No External IP Address",
+        description="True if there is no external IP address on the VM.",
+    )
+
+
+class ServiceAccountConfig(BaseModel):
+    email: str = Field(
+        default="",
+        title="Service Account Email",
+        description="The email of the service account to use for the job.",
+    )
+    scopes: list[str] = Field(
+        default_factory=list,
+        title="Service Account Scopes",
+        description="The scopes to use for the service account.",
+    )
+
+
 class EnvironmentConfig(BaseModel):
     region: str = Field(
         title="Region",
@@ -22,6 +53,16 @@ class EnvironmentConfig(BaseModel):
         default="",
         title="BigQuery Benchmarking Table",
         description="The fully qualified name (project.dataset.table) of the BigQuery table to write benchmarking data to. Default/blank: don't save benchmarking.",
+    )
+    networking_interface: NetworkInterfaceConfig = Field(
+        default_factory=NetworkInterfaceConfig,
+        title="Networking Interface",
+        description="The networking interface configuration for the job.",
+    )
+    service_account: ServiceAccountConfig = Field(
+        default_factory=ServiceAccountConfig,
+        title="Service Account",
+        description="The service account configuration for the job.",
     )
 
 


### PR DESCRIPTION
This allows users to set the networking & service account in the environment config. This is required in our target production environment.

Fixes #337 

Paired with @WeihaoGe1009 