### PR TITLE
Use image name as benchmarking input id

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -86,14 +86,11 @@ def main():
     if benchmark_output_uri:
         gpu_info = benchmark_utils.get_gpu_info()
 
-        parsed_url = urllib.parse.urlparse(image_uri)
-        filename = parsed_url.path.split("/")[-2]
-
         # BigQuery datetimes don't have a timezone.
         benchmark_time = datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
 
         timing_info = {
-            "input_file_id": filename,
+            "input_file_id": args.image_name,
             "numpy_size_mb": round(input_channels.nbytes / 1e6, 2),
             "pixels_m": input_channels.shape[0] * input_channels.shape[1],
             "benchmark_datetime_utc": benchmark_time,

--- a/src/deepcell_imaging/gcp_batch_jobs/segment.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/segment.py
@@ -95,6 +95,7 @@ def make_segment_preprocess_tasks(
         preprocess_tasks.append(
             PreprocessArgs(
                 image_uri=task.input_channels_path,
+                image_name=task.image_name,
                 output_uri=f"{task_directory}/preprocessed.npz.gz",
                 benchmark_output_uri=(
                     f"{task_directory}/preprocess_benchmark.json"
@@ -329,6 +330,7 @@ def make_segmentation_tasks(image_names, npz_root, npz_names, masks_output_root)
 
         yield SegmentationTask(
             input_channels_path=npz_path,
+            image_name=image_name,
             wholecell_tiff_output_uri=wholecell_tiff_output_uri,
             nuclear_tiff_output_uri=nuclear_tiff_output_uri,
             input_image_rows=input_image_shape[0],

--- a/src/deepcell_imaging/gcp_batch_jobs/types.py
+++ b/src/deepcell_imaging/gcp_batch_jobs/types.py
@@ -74,6 +74,7 @@ class SegmentationTask(BaseModel):
     """
 
     input_channels_path: str
+    image_name: str
     wholecell_tiff_output_uri: str = ""
     nuclear_tiff_output_uri: str = ""
     input_image_rows: int
@@ -84,6 +85,10 @@ class PreprocessArgs(BaseModel):
     image_uri: str = Field(
         title="Image URI",
         description="URI to input image npz file, containing an array named 'input_channels' by default (see --image-array-name)",
+    )
+    image_name: str = Field(
+        title="Image Name",
+        description="Name of the input image.",
     )
     image_array_name: str = Field(
         default="input_channels",

--- a/tests/deepcell_imaging/gcp_batch_jobs/quantify_test.py
+++ b/tests/deepcell_imaging/gcp_batch_jobs/quantify_test.py
@@ -37,6 +37,10 @@ def test_make_quantify_job(_patched_open):
                             },
                         },
                     ],
+                    "environment": {
+                        "variables": {"TMPDIR": ANY},
+                    },
+                    "volumes": ANY,
                 },
                 "taskCount": 1,
                 "taskCountPerNode": 1,
@@ -49,6 +53,7 @@ def test_make_quantify_job(_patched_open):
                     "policy": {
                         "machineType": "n1-standard-8",
                         "provisioningModel": "SPOT",
+                        "disks": ANY,
                     },
                 },
             ],

--- a/tests/deepcell_imaging/gcp_batch_jobs/segment_test.py
+++ b/tests/deepcell_imaging/gcp_batch_jobs/segment_test.py
@@ -22,6 +22,7 @@ def test_make_segmentation_tasks(_mock_npz_headers):
     assert list(tasks) == [
         SegmentationTask(
             input_channels_path="gs://a-dataset/NPZ_INTERMEDIATE/a-prefix.npz",
+            image_name="a-prefix",
             wholecell_tiff_output_uri="gs://a-dataset/SEGMASK/a-prefix_WholeCellMask.tiff",
             nuclear_tiff_output_uri="gs://a-dataset/SEGMASK/a-prefix_NuclearMask.tiff",
             input_image_rows=123,
@@ -29,6 +30,7 @@ def test_make_segmentation_tasks(_mock_npz_headers):
         ),
         SegmentationTask(
             input_channels_path="gs://a-dataset/NPZ_INTERMEDIATE/b-prefix.npz",
+            image_name="b-prefix",
             wholecell_tiff_output_uri="gs://a-dataset/SEGMASK/b-prefix_WholeCellMask.tiff",
             nuclear_tiff_output_uri="gs://a-dataset/SEGMASK/b-prefix_NuclearMask.tiff",
             input_image_rows=123,
@@ -46,6 +48,7 @@ def test_build_segment_job_tasks():
         tasks=[
             SegmentationTask(
                 input_channels_path="/channels/path",
+                image_name="an-image",
                 wholecell_tiff_output_uri="/tiff/wholecell/path",
                 nuclear_tiff_output_uri="/tiff/nuclear/path",
                 input_image_rows=123,
@@ -110,6 +113,10 @@ def test_build_segment_job_tasks():
                             },
                         },
                     ],
+                    "environment": {
+                        "variables": {"TMPDIR": ANY},
+                    },
+                    "volumes": ANY,
                 },
                 "taskCount": 1,
                 "taskCountPerNode": 1,
@@ -129,6 +136,7 @@ def test_build_segment_job_tasks():
                                 "count": 1,
                             },
                         ],
+                        "disks": ANY,
                     },
                 },
             ],


### PR DESCRIPTION
Require passing in the image name. Previously, we guessed it from the filename using the directory containing the npz file. This is incorrect for QuPath project structures where the filename itself is the image name. Now, the job submission script has to decide what to call each image.

Also fix unit tests– we had forgotten to update them after adding the disks 😅

Fixes #330 

Paired with @WeihaoGe1009 