### PR TITLE
Separate DockerHub push from main build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,5 +29,10 @@ jobs:
         run: "gcloud info"
 
       - name: Trigger cloud build
-        run: "gcloud builds submit --region=${{ vars.GCP_REGION }} --config=build-batch-container.yaml --substitutions=_DOCKERHUB_REPOSITORY=${{ vars.DOCKERHUB_REPOSITORY }},_GCP_REPOSITORY=${{ vars.GCP_ARTIFACT_REPOSITORY }} ."
+        run: "gcloud builds submit --region=${{ vars.GCP_REGION }} --config=build-batch-container.yaml --substitutions=_GCP_REPOSITORY=${{ vars.GCP_ARTIFACT_REPOSITORY }} ."
+        working-directory: container
+
+      - name: Push to DockerHub
+        if: ${{ vars.DOCKERHUB_REPOSITORY != '' }}
+        run: "gcloud builds submit --region=${{ vars.GCP_REGION }} --config=push-dockerhub-container.yaml --substitutions=_DOCKERHUB_REPOSITORY=${{ vars.DOCKERHUB_REPOSITORY }},_GCP_REPOSITORY=${{ vars.GCP_ARTIFACT_REPOSITORY }},_DOCKERHUB_USERNAME_SECRET_NAME=${{ vars.DOCKERHUB_USERNAME_SECRET_NAME }},_DOCKERHUB_PASSWORD_SECRET_NAME=${{ vars.DOCKERHUB_PASSWORD_SECRET_NAME }} ."
         working-directory: container

--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ TLDR,
 Set these repository variables:
 
 - `DOCKERHUB_REPOSITORY` eg `dchaley`
+  - If you set this, you need to set these further variables:
+    - `_DOCKERHUB_USERNAME_SECRET_NAME` eg `dockerhub-username/versions/1`
+    - `_DOCKERHUB_PASSWORD_SECRET_NAME` eg `dockerhub-password/versions/1`
+
+  - And you need the corresponding secrets in the GCP project.
+
 - `GCP_ARTIFACT_REPOSITORY` eg `my-repository`
 - `GCP_PROJECT_ID` eg `my-gcp-project-4321`
 - `GCP_REGION` eg `us-central1`

--- a/container/build-batch-container.yaml
+++ b/container/build-batch-container.yaml
@@ -1,36 +1,21 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
     entrypoint: 'bash'
-    args: [ '-c', 'echo "$$PASSWORD" | docker login --username=$$USERNAME --password-stdin' ]
-    secretEnv: [ 'USERNAME', 'PASSWORD' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    entrypoint: 'bash'
     args: [ '-c', 'docker pull ${_GCP_CONTAINER} || exit 0' ]
   - name: 'gcr.io/cloud-builders/docker'
     args: [
       'build',
       '--cache-from', '${_GCP_CONTAINER}',
       '-t', '${_GCP_CONTAINER}',
-      '-t', '${_DOCKERHUB_CONTAINER}',
       '.',
     ]
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'push', '${_GCP_CONTAINER}' ]
-  - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'push', '${_DOCKERHUB_CONTAINER}' ]
 substitutions:
   # Assumes these substitutions are available:
   # - $_GCP_REPOSITORY
-  # - $_DOCKERHUB_REPOSITORY
   _TAGGED_IMAGE: ${_IMAGE_NAME:-deepcell-segmentation}:${_IMAGE_TAG:-latest}
   _GCP_CONTAINER_BASE: ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_GCP_REPOSITORY}
   _GCP_CONTAINER: ${_GCP_CONTAINER_BASE}/${_TAGGED_IMAGE}
-  _DOCKERHUB_CONTAINER: ${_DOCKERHUB_REPOSITORY}/${_TAGGED_IMAGE}
 options:
   dynamicSubstitutions: true
-availableSecrets:
-  secretManager:
-    - versionName: projects/$PROJECT_ID/secrets/dockerhub-password/versions/1
-      env: 'PASSWORD'
-    - versionName: projects/$PROJECT_ID/secrets/dockerhub-username/versions/2
-      env: 'USERNAME'

--- a/container/push-dockerhub-container.yaml
+++ b/container/push-dockerhub-container.yaml
@@ -1,0 +1,29 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: [ '-c', 'echo "$$PASSWORD" | docker login --username=$$USERNAME --password-stdin' ]
+    secretEnv: [ 'USERNAME', 'PASSWORD' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: [ '-c', 'docker pull ${_GCP_CONTAINER}' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    entrypoint: 'bash'
+    args: [ '-c', 'docker image tag ${_GCP_CONTAINER} ${_DOCKERHUB_CONTAINER}' ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args: [ 'push', '${_DOCKERHUB_CONTAINER}' ]
+substitutions:
+  # Assumes these substitutions are available:
+  # - $_GCP_REPOSITORY
+  # - $_DOCKERHUB_REPOSITORY
+  _TAGGED_IMAGE: ${_IMAGE_NAME:-deepcell-segmentation}:${_IMAGE_TAG:-latest}
+  _GCP_CONTAINER_BASE: ${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_GCP_REPOSITORY}
+  _GCP_CONTAINER: ${_GCP_CONTAINER_BASE}/${_TAGGED_IMAGE}
+  _DOCKERHUB_CONTAINER: ${_DOCKERHUB_REPOSITORY}/${_TAGGED_IMAGE}
+options:
+  dynamicSubstitutions: true
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/${_DOCKERHUB_PASSWORD_SECRET_NAME}
+      env: 'PASSWORD'
+    - versionName: projects/$PROJECT_ID/secrets/${_DOCKERHUB_USERNAME_SECRET_NAME}
+      env: 'USERNAME'


### PR DESCRIPTION
The target environment shouldn't push to Docker Hub. Add condition to Docker Hub push, and do it separately.

This does mean the 2nd build needs to re-pull the container in order to add the tag and push it to Docker Hub. Oh, well…